### PR TITLE
feat: chart legend support single select mode.

### DIFF
--- a/demos/legend-single-selectedMode.html
+++ b/demos/legend-single-selectedMode.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>图例单选模式</title>
+  <link rel="stylesheet" href="./assets/common.css">
+</head>
+<body>
+<div>
+  <canvas id="mountNode" style="position: relative;">
+  </canvas>
+</div>
+<script src="./assets/jquery-3.2.1.min.js"></script>
+<script src="../build/f2.js"></script>
+<script>
+const origin =[{ name: 'Installation', data: [43934, 52503, 57177, 69658, 97031, 119931, 137133, 154175] }, { name: 'Manufacturing',
+data: [24916, 24064, 29742, 29851, 32490, 30282, 38121, 40434] }, { name: 'Sales & Distribution', data: [11744, 17722, 16005,
+19771, 20185, 24377, 32147, 39387] }, { name: 'Project Development', data: [null, null, 7988, 12169, 15112, 22452, 34400,
+34227] }, { name: 'Other', data: [12908, 5948, 8105, 11248, 8989, 11816, 18274, 18111] }];
+
+const source = [];
+origin.map(obj => {
+  const { name, data } = obj;
+  let year = 2010;
+  data.map((val, index)=> {
+    const item = {};
+    item.name = name;
+    item.value = val;
+    item.year = year + index;
+    source.push(item);
+  });
+});
+
+const chart = new F2.Chart({
+  id: 'mountNode',
+  width: window.innerWidth,
+  height: 260,
+  pixelRatio: window.devicePixelRatio // 指定分辨率
+});
+
+chart.source(source, {
+  value: {
+    tickCount: 5
+  }
+});
+chart.legend({
+  position: 'right',
+  selectedMode: 'single'
+});
+chart.line().position('year*value').color('name');
+chart.render();
+</script>
+</body>
+</html>

--- a/src/plugin/legend.js
+++ b/src/plugin/legend.js
@@ -28,7 +28,8 @@ const DEFAULT_CFG = {
   },
   unCheckColor: '#bfbfbf',
   itemWidth: 'auto',
-  wordSpace: 6
+  wordSpace: 6,
+  selectedMode: 'multiple' // 'multiple' or 'single'
 };
 
 // Register the default configuration for Legend
@@ -334,22 +335,31 @@ class LegendController {
     const clicked = findItem(x, y);
     if (clicked && clicked.clickedLegend.clickable !== false) {
       const { clickedItem, clickedLegend } = clicked;
-      if (clickedLegend.onClick) {
+      if (clickedLegend.onClick) { // 用户自定义点击行为
         ev.clickedItem = clickedItem;
         clickedLegend.onClick(ev);
-      } else if (!clickedLegend.custom) {
-        const filterVals = clickedLegend.filterVals;
-        const field = clickedLegend.field;
+      } else if (!clickedLegend.custom) { // 进入组件默认事件处理逻辑
         const checked = clickedItem.get('checked');
         const value = clickedItem.get('dataValue');
-        if (!checked) {
-          filterVals.push(value);
+        const { filterVals, field, selectedMode } = clickedLegend;
+        const isSingeSelected = selectedMode === 'single';
+
+        if (isSingeSelected) {
+          chart.filter(field, val => {
+            return val === value;
+          });
         } else {
-          Util.Array.remove(filterVals, value);
+          if (!checked) {
+            filterVals.push(value);
+          } else {
+            Util.Array.remove(filterVals, value);
+          }
+
+          chart.filter(field, val => {
+            return filterVals.indexOf(val) !== -1;
+          });
         }
-        chart.filter(field, val => {
-          return filterVals.indexOf(val) !== -1;
-        });
+
         chart.repaint();
       }
     }

--- a/test/unit/plugin/legend-spec.js
+++ b/test/unit/plugin/legend-spec.js
@@ -340,7 +340,7 @@ describe('Legend Plugin', function() {
     chart.destroy();
   });
 
-  it('handle event', function(done) {
+  it('handle event, selectedMode is multiple', function(done) {
     chart = new F2.Chart({
       id: 'chart-legend',
       width: 400,
@@ -364,6 +364,41 @@ describe('Legend Plugin', function() {
       const legendController = chart.get('legendController');
       const legend = legendController.legends.top[0];
       expect(legend.items[0].checked).to.be.false;
+      chart.destroy();
+      // document.body.removeChild(canvas);
+      done();
+    }, 1000);
+  });
+
+  it('handle event, selectedMode is single', function(done) {
+    chart = new F2.Chart({
+      id: 'chart-legend',
+      width: 400,
+      height: 300,
+      plugins: Legend,
+      pixelRatio: 2
+    });
+    chart.source(data);
+    chart.legend({
+      triggerOn: 'click',
+      selectedMode: 'single'
+    });
+    chart.interval().position('genre*sold').color('genre');
+    chart.render();
+
+    gestureSimulator(canvas, 'click', {
+      clientX: 39,
+      clientY: 19
+    });
+
+    setTimeout(function() {
+      const legendController = chart.get('legendController');
+      const legend = legendController.legends.top[0];
+      const legendItems = legend.items;
+      expect(legendItems[0].checked).to.be.true;
+      for (let i = 1; i < legendItems.length; i++) {
+        expect(legendItems[1].checked).to.be.false;
+      }
       chart.destroy();
       document.body.removeChild(canvas);
       done();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change

<!-- Provide a description of the change below this comment. -->

Closed #131 .

图例支持单选模式：

```js
chart.legend({
  selectedMode: 'multiple' || 'single'  // 默认多选
})
```

![default](https://user-images.githubusercontent.com/6628666/40402274-45783588-5e7d-11e8-91cb-a2dfad65a118.gif)
