### PR TITLE
guide support point type

### DIFF
--- a/demos/line-with-guide-point.html
+++ b/demos/line-with-guide-point.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>多条折线(HighCharts)</title>
+  <link rel="stylesheet" href="./assets/common.css">
+</head>
+<body>
+<div>
+  <canvas id="mountNode"></canvas>
+</div>
+<script src="./assets/jquery-3.2.1.min.js"></script>
+<script src="../build/f2-all.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/lodash@4.17.4/lodash.min.js"></script>
+
+<script>
+  const data = [
+    { name: 'Installation', value: 43934, year: '2010' },
+    { name: 'Installation', value: 52503, year: '2011' },
+    { name: 'Installation', value: 57177, year: '2012' },
+    { name: 'Installation', value: 69658, year: '2013' },
+    { name: 'Installation', value: 97031, year: '2014' },
+    { name: 'Installation', value: 119931, year: '2015' },
+    { name: 'Installation', value: 137133, year: '2016' },
+    { name: 'Installation', value: 154175, year: '2017' },
+    { name: 'Manufacturing', value: 24916, year: '2010' },
+    { name: 'Manufacturing', value: 24064, year: '2011' },
+    { name: 'Manufacturing', value: 29742, year: '2012' },
+    { name: 'Manufacturing', value: 29851, year: '2013' },
+    { name: 'Manufacturing', value: 32490, year: '2014' },
+    { name: 'Manufacturing', value: 30282, year: '2015' },
+    { name: 'Manufacturing', value: 38121, year: '2016' },
+    { name: 'Manufacturing', value: 40434, year: '2017' },
+    { name: 'Sales & Distribution', value: 11744, year: '2010' },
+    { name: 'Sales & Distribution', value: 17722, year: '2011' },
+    { name: 'Sales & Distribution', value: 16005, year: '2012' },
+    { name: 'Sales & Distribution', value: 19771, year: '2013' },
+    { name: 'Sales & Distribution', value: 20185, year: '2014' },
+    { name: 'Sales & Distribution', value: 24377, year: '2015' },
+    { name: 'Sales & Distribution', value: 32147, year: '2016' },
+    { name: 'Sales & Distribution', value: 39387, year: '2017' },
+    { name: 'Project Development', value: 10300, year: '2010' },
+    { name: 'Project Development', value: 24377, year: '2011' },
+    { name: 'Project Development', value: 7988, year: '2012' },
+    { name: 'Project Development', value: 12169, year: '2013' },
+    { name: 'Project Development', value: 15112, year: '2014' },
+    { name: 'Project Development', value: 22452, year: '2015' },
+    { name: 'Project Development', value: 34400, year: '2016' },
+    { name: 'Project Development', value: 34227, year: '2017' },
+    { name: 'Other', value: 12908, year: '2010' },
+    { name: 'Other', value: 5948, year: '2011' },
+    { name: 'Other', value: 8105, year: '2012' },
+    { name: 'Other', value: 11248, year: '2013' },
+    { name: 'Other', value: 8989, year: '2014' },
+    { name: 'Other', value: 11816, year: '2015' },
+    { name: 'Other', value: 18274, year: '2016' },
+    { name: 'Other', value: 18111, year: '2017' }
+  ];
+
+  const chart = new F2.Chart({
+    id: 'mountNode',
+    width: window.innerWidth,
+    height: window.innerWidth * 0.8,
+    pixelRatio: window.devicePixelRatio
+  });
+
+  chart.source(data, {
+    value: {
+      tickCount: 5,
+      min: 0
+    },
+    year: {
+      range: [ 0, 1 ]
+    }
+  });
+  chart.legend({
+    position: 'bottom'
+  });
+  chart.tooltip(false);
+  chart.axis('year', {
+    label(text, index, total) {
+      const textCfg = {};
+      if (index === 0) {
+        textCfg.textAlign = 'left';
+      }
+      if (index === total - 1) {
+        textCfg.textAlign = 'right';
+      }
+      return textCfg;
+    }
+  });
+  chart.line().position('year*value').color('name');
+
+  // 添加辅助点标记
+  chart.guide().point({
+    position: ["2011", 5948],
+    offsetY: 0,
+    pointStyle: {
+      fill: '#8659AF',
+      r: 10,
+    }
+  });
+
+  chart.render();
+</script>
+</body>
+</html>

--- a/demos/radar-with-guide-point.html
+++ b/demos/radar-with-guide-point.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>雷达图（面积图）</title>
+  <link rel="stylesheet" href="./assets/common.css">
+</head>
+<body>
+<div>
+  <canvas id="mountNode"></canvas>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/lodash@4.17.4/lodash.min.js"></script>
+<script src="./assets/jquery-3.2.1.min.js"></script>
+<script src="../build/f2-all.js"></script>
+<script>
+  const { Util, Global } = F2;
+  const data = [
+    { item: 'Design', user: '用户 A', score: 70 },
+    { item: 'Design', user: '用户 B', score: 30 },
+    { item: 'Development', user: '用户 A', score: 60 },
+    { item: 'Development', user: '用户 B', score: 70 },
+    { item: 'Marketing', user: '用户 A', score: 50 },
+    { item: 'Marketing', user: '用户 B', score: 60 },
+    { item: 'Users', user: '用户 A', score: 40 },
+    { item: 'Users', user: '用户 B', score: 50 },
+    { item: 'Test', user: '用户 A', score: 60 },
+    { item: 'Test', user: '用户 B', score: 70 },
+    { item: 'Language', user: '用户 A', score: 70 },
+    { item: 'Language', user: '用户 B', score: 50 },
+    { item: 'Technology', user: '用户 A', score: 70 },
+    { item: 'Technology', user: '用户 B', score: 40 },
+    { item: 'Support', user: '用户 A', score: 60 },
+    { item: 'Support', user: '用户 B', score: 40 }
+  ];
+  const chart = new F2.Chart({
+    id: 'mountNode',
+    width: window.innerWidth,
+    height: window.innerWidth * 0.75,
+    pixelRatio: window.devicePixelRatio
+  });
+
+  chart.coord('polar');
+  chart.source(data, {
+    score: {
+      min: 0,
+      max: 120,
+      nice: false,
+      tickCount: 4
+    }
+  });
+  chart.tooltip({
+    custom: true,
+    onChange(obj) {
+      const legend = chart.get('legendController').legends.top[0];
+      const tooltipItems = obj.items;
+      const legendItems = legend.items;
+      const map = {};
+      legendItems.map(item => {
+        map[item.name] = _.clone(item);
+      });
+      tooltipItems.map(item => {
+        const { name, value } = item;
+        if (map[name]) {
+          map[name].value = value;
+        }
+      });
+      legend.setItems(Object.values(map));
+    },
+    onHide(tooltip) {
+      const legend = chart.get('legendController').legends.top[0];
+      legend.setItems(chart.getLegendItems().country);
+    }
+  });
+  chart.axis('score', {
+    label(text, index, total) {
+      if (index === total - 1) {
+        return null;
+      }
+      return {
+        top: true
+      }
+    },
+    grid(text, index) {
+      if (text === '120') {
+        return {
+          lineDash: null
+        };
+      }
+    }
+  });
+  chart.area().position('item*score').color('user');
+  chart.line().position('item*score').color('user');
+  chart.point().position('item*score').color('user').style({
+    stroke: '#fff',
+    lineWidth: 1
+  });
+
+  // 添加辅助点标记 覆盖特殊能力维度
+  chart.guide().line({
+    start: ["Design", 70],
+    end: ["Development", 60],
+    style: {
+      stroke: '#ececec',
+      lineWidth: 3
+    }
+  });
+  chart.guide().line({
+    start: ["Design", 70],
+    end: ["Support", 60],
+    style: {
+      stroke: '#ececec',
+      lineWidth: 3
+    }
+  });
+  chart.guide().point({
+    position: ["Design", 70],
+    offsetY: 0,
+    pointStyle: {
+      fill: '#ececec',
+      r: 3,
+    }
+  });
+  chart.guide().point({
+    position: ["Development", 60],
+    offsetY: 0,
+    pointStyle: {
+      fill: '#ececec',
+      r: 3,
+    }
+  });
+  chart.guide().point({
+    position: ["Support", 60],
+    offsetY: 0,
+    pointStyle: {
+      fill: '#ececec',
+      r: 3,
+    }
+  });
+
+  chart.render();
+</script>
+</body>
+</html>

--- a/src/component/guide/index.js
+++ b/src/component/guide/index.js
@@ -5,5 +5,6 @@ module.exports = {
   Rect: require('./rect'),
   Html: require('./html'),
   Tag: require('./tag'),
+  Point: require('./point'),
   RegionFilter: require('./region-filter')
 };

--- a/src/component/guide/point.js
+++ b/src/component/guide/point.js
@@ -26,7 +26,7 @@ class Point extends GuideBase {
       className: 'guide-point-point',
       attrs: Util.mix({
         x: position.x + this.offsetX,
-        y: position.y + this.offsetY,
+        y: position.y + this.offsetY
       }, this.pointStyle)
     });
 

--- a/src/component/guide/point.js
+++ b/src/component/guide/point.js
@@ -1,0 +1,38 @@
+const Util = require('../../util/common');
+const GuideBase = require('./base');
+
+class Point extends GuideBase {
+  _initDefaultCfg() {
+    this.type = 'point';
+    this.position = null;
+    this.offsetX = 0;
+    this.offsetY = 0;
+    this.pointStyle = {
+      fill: '#1890FF',
+      r: 3,
+      lineWidth: 1,
+      stroke: '#fff'
+    };
+  }
+
+  render(coord, container) {
+    const position = this.parsePoint(coord, this.position);
+
+    const wrapperContainer = container.addGroup({
+      className: 'guide-point'
+    });
+
+    wrapperContainer.addShape('Circle', {
+      className: 'guide-point-point',
+      attrs: Util.mix({
+        x: position.x + this.offsetX,
+        y: position.y + this.offsetY,
+      }, this.pointStyle)
+    });
+
+    this.element = wrapperContainer;
+  }
+}
+
+GuideBase.Point = Point;
+module.exports = Point;

--- a/src/plugin/guide.js
+++ b/src/plugin/guide.js
@@ -55,6 +55,17 @@ Global.guide = Util.deepMix({
       textAlign: 'center',
       textBaseline: 'middle'
     }
+  },
+  point: {
+    top: true,
+    offsetX: 0, // X 轴偏移
+    offsetY: 0, // Y 轴偏移
+    pointStyle: {
+      fill: '#1890FF',
+      r: 3,
+      lineWidth: 1,
+      stroke: '#fff'
+    }
   }
 }, Global.guide || {});
 
@@ -123,6 +134,10 @@ class GuideController {
 
   tag(cfg = {}) {
     return this._createGuide('tag', cfg);
+  }
+
+  point(cfg = {}) {
+    return this._createGuide('point', cfg);
   }
 
   regionFilter(cfg = {}) {

--- a/test/bug/guide-html-spec.js
+++ b/test/bug/guide-html-spec.js
@@ -39,8 +39,8 @@ describe('The position calculate of Guide.HTML', () => {
     chart.render();
 
     const guideEle = $('#guide');
-    expect(guideEle.position().top).to.eql(216);
-    expect(guideEle.position().left).to.eql(172);
+    expect(Math.round(guideEle.position().top)).to.eql(216);
+    expect(Math.round(guideEle.position().left)).to.eql(172);
     const wrapper = $('#chartWrapper')[0];
     document.body.removeChild(wrapper);
   });

--- a/test/unit/graphic/shape/text-spec.js
+++ b/test/unit/graphic/shape/text-spec.js
@@ -61,7 +61,7 @@ describe('Text', function() {
     const bbox = text.getBBox();
     expect(bbox.x).to.equal(30);
     expect(bbox.y).to.equal(18);
-    expect(bbox.width).to.equal(26.23046875);
+    expect(bbox.width).to.equal(30);
     expect(bbox.height).to.equal(12);
   });
 

--- a/test/unit/guide/point-spec.js
+++ b/test/unit/guide/point-spec.js
@@ -36,14 +36,14 @@ describe('Guide.Point', function() {
   });
 
   it('guide point', function() {
-    let point = new Point({
+    const point = new Point({
       xScale,
       yScales: [ yScale ],
       position: [ 0, 'min' ]
     });
     point.render(coord, group);
     canvas.draw();
-    circle = group.get('children')[0].get('children')[0];
+    const circle = group.get('children')[0].get('children')[0];
     expect(circle.attr('x')).to.equal(60);
     expect(circle.attr('y')).to.equal(400);
     canvas.destroy();

--- a/test/unit/guide/point-spec.js
+++ b/test/unit/guide/point-spec.js
@@ -1,0 +1,53 @@
+const expect = require('chai').expect;
+const { Canvas } = require('../../../src/graphic/index');
+const Coord = require('../../../src/coord/index');
+const { Point } = require('../../../src/component/guide/index');
+const Scale = require('../../../src/scale/index');
+
+const canvas1 = document.createElement('canvas');
+canvas1.id = 'guidePoint';
+canvas1.style.position = 'fixed';
+canvas1.style.top = 0;
+canvas1.style.left = 0;
+document.body.appendChild(canvas1);
+
+describe('Guide.Point', function() {
+  const coord = new Coord.Rect({
+    start: { x: 60, y: 400 },
+    end: { x: 460, y: 60 }
+  });
+
+  const canvas = new Canvas({
+    el: 'guidePoint',
+    width: 500,
+    height: 500,
+    pixelRatio: 2
+  });
+
+  const group = canvas.addGroup();
+
+  const xScale = new Scale.Cat({
+    values: [ '一月', '二月', '三月', '四月', '五月' ]
+  });
+
+  const yScale = new Scale.Linear({
+    min: 0,
+    max: 1200
+  });
+
+  it('guide point', function() {
+    let point = new Point({
+      xScale,
+      yScales: [ yScale ],
+      position: [ 0, 'min' ]
+    });
+    point.render(coord, group);
+    canvas.draw();
+    circle = group.get('children')[0].get('children')[0];
+    expect(circle.attr('x')).to.equal(60);
+    expect(circle.attr('y')).to.equal(400);
+    canvas.destroy();
+    document.body.removeChild(canvas1);
+
+  });
+});

--- a/test/unit/plugin/guide-spec.js
+++ b/test/unit/plugin/guide-spec.js
@@ -37,7 +37,7 @@ describe('Guide Plugin', function() {
 
     guideController = chart.get('guideController');
     expect(guideController).not.to.be.empty;
-    expect(F2.Global.guide).to.have.all.keys('line', 'text', 'rect', 'arc', 'html', 'tag');
+    expect(F2.Global.guide).to.have.all.keys('line', 'text', 'rect', 'arc', 'html', 'tag', 'point');
     expect(F2.Global.guide.line).to.eql({
       style: {
         stroke: '#a3a3a3',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

Guide 辅助元素新增支持绘制图表辅助点功能。

```
chart.guide().point({})

绘制辅助点。

chart.guide().tag({
  top: {Boolean}, // 指定 guide 是否绘制在 canvas 最上层，默认为 true, 即绘制在最上层
  position: {Function} | {Array}, // Point 的起始位置，值为原始数据值，支持 callback
  offsetX: {Number}, // X 轴偏移，默认为 0
  offsetY: {Number}, // Y 轴偏移，默认为 0
  pointStyle: {
    fill: '#1890FF', // 填充颜色
    r: 3, // 半径
    lineWidth: 1, // 线的边框
    stroke: '#fff' // 线的描边
  } // 点的样式
});
```

单元测试：
test/unit/guide/point-spec.js

使用示例： 
demos/line-with-guide-point.html
demos/radar-with-guide-point.html

最后，测试过程中发现如下两个文件用例在提交代码前npm run test无法通过测试，已修复，请确认。
test/bug/guide-html-spec.js
test/unit/graphic/shape/text-spec.js