### PR TITLE
Fix:[node canvas gradient.addColorStop issue]

### DIFF
--- a/src/graphic/util/style-parse.js
+++ b/src/graphic/util/style-parse.js
@@ -3,7 +3,7 @@ const Util = require('../../util/common');
 function _addStop(steps, gradient) {
   Util.each(steps, item => {
     item = item.split(':');
-    gradient.addColorStop(item[0], item[1]);
+    gradient.addColorStop(Number(item[0]), item[1]);
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
node-canvas渲染渐变色报错，TypeError: offset required
原因是gradient.addColorStop第一个参数必须是Number，而提供的是数字字符串