### PR TITLE
feat: support 'x', 'y', 'xy' three types for tooltip crosshairs, and …

### DIFF
--- a/demos/candlestick.html
+++ b/demos/candlestick.html
@@ -37,6 +37,10 @@
         tickCount: 3
       }
     });
+    chart.tooltip({
+      showCrosshairs: true,
+      showXTip: true
+    });
 
     chart.axis('time', {
       label(text, index, total) {

--- a/src/component/text-box.js
+++ b/src/component/text-box.js
@@ -1,0 +1,142 @@
+const Util = require('../util/common');
+const { Group } = require('../graphic/index');
+
+class TextBox {
+  getDefaultCfg() {
+    return {
+      x: 0,
+      y: 0,
+      content: '',
+      textStyle: {
+        fontSize: 12,
+        fill: '#fff',
+        textAlign: 'center',
+        textBaseline: 'middle'
+      },
+      background: {
+        radius: 1,
+        fill: 'rgba(0, 0, 0, 0.65)',
+        padding: [ 3, 5 ]
+      },
+      width: 0,
+      height: 0,
+      className: ''
+    };
+  }
+
+  constructor(cfg) {
+    Util.deepMix(this, this.getDefaultCfg(), cfg);
+    this._init();
+    const { content, x, y } = this;
+
+    if (!Util.isNil(content)) {
+      this.updateContent(content);
+    }
+
+    this.updatePosition(x, y);
+  }
+
+  _init() {
+    const { content, textStyle, background, className, visible } = this;
+    const container = new Group({
+      className,
+      zIndex: 0,
+      visible
+    });
+    const text = container.addShape('Text', {
+      className: className + '-text',
+      zIndex: 1,
+      attrs: Util.mix({
+        text: content,
+        x: 0,
+        y: 0
+      }, textStyle)
+    });
+    const backgroundShape = container.addShape('Rect', {
+      className: className + '-bg',
+      zIndex: -1,
+      attrs: Util.mix({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0
+      }, background)
+    });
+    container.sort();
+    this.container = container;
+    this.textShape = text;
+    this.backgroundShape = backgroundShape;
+  }
+
+  _getBBox() {
+    const textShape = this.textShape;
+    const background = this.background;
+    const textBBox = textShape.getBBox();
+    const padding = Util.parsePadding(background.padding);
+    const width = textBBox.width + padding[1] + padding[3];
+    const height = textBBox.height + padding[0] + padding[2];
+    const x = textBBox.minX - padding[3];
+    const y = textBBox.minY - padding[0];
+    return {
+      x,
+      y,
+      width,
+      height
+    };
+  }
+
+  updateContent(text) {
+    const { textShape, backgroundShape } = this;
+    if (!Util.isNil(text)) {
+      textShape.attr('text', text);
+      // update box shape
+      const { x, y, width: tipWidth, height: tipHeight } = this._getBBox();
+      const width = this.width || tipWidth;
+      const height = this.height || tipHeight;
+      backgroundShape.attr({
+        x,
+        y,
+        width,
+        height
+      });
+      this._width = width;
+      this._height = height;
+      this.content = text;
+    }
+  }
+
+  updatePosition(x, y) {
+    const container = this.container;
+    const { x: xMin, y: yMin } = this._getBBox();
+    container.moveTo(x - xMin, y - yMin);
+    this.x = x - xMin;
+    this.y = y - yMin;
+  }
+
+  getWidth() {
+    return this._width;
+  }
+
+  getHeight() {
+    return this._height;
+  }
+
+  show() {
+    this.container.show();
+  }
+
+  hide() {
+    this.container.hide();
+  }
+
+  clear() {
+    const container = this.container;
+    container.clear();
+    container.remove(true);
+    this.container = null;
+    this.textShape = null;
+    this.backgroundShape = null;
+  }
+}
+
+module.exports = TextBox;

--- a/src/component/tooltip.js
+++ b/src/component/tooltip.js
@@ -98,10 +98,9 @@ class Tooltip {
           className: 'tooltip-arrow',
           visible: false,
           zIndex: 2,
-          attrs: {
-            points: [],
-            fill: background.fill
-          }
+          attrs: Util.mix({
+            points: []
+          }, background)
         });
       }
     }

--- a/src/plugin/tooltip.js
+++ b/src/plugin/tooltip.js
@@ -285,12 +285,11 @@ class TooltipController {
         tooltipMarkerCfg
       });
     }
-
-    if (!cfg.custom) {
-      const first = items[0];
-      const title = first.title || first.name;
-      tooltip.setContent(title, items);
-    }
+    const chart = this.chart;
+    const coord = chart.get('coord');
+    const first = items[0];
+    const title = first.title || first.name;
+    tooltip.setContent(title, items, coord.transposed);
     tooltip.setPosition(items);
 
     const markerItems = tooltipMarkerCfg.items;

--- a/test/unit/plugin/tooltip-spec.js
+++ b/test/unit/plugin/tooltip-spec.js
@@ -279,6 +279,81 @@ describe('Tooltip Plugin', function() {
     expect(tooltip.items[0].name).to.equal('score');
     expect(tooltip.items[0].value).to.equal('148');
     chart.destroy();
+  });
+});
+
+describe('Tooltip crosshairs', function() {
+  const data = [
+    { date: '2018-04-21', steps: 59 },
+    { date: '2018-04-22', steps: 2515 },
+    { date: '2018-04-23', steps: 6524 },
+    { date: '2018-04-24', steps: 26044 },
+    { date: '2018-04-25', steps: 29763 },
+    { date: '2018-04-26', steps: 10586 },
+    { date: '2018-04-27', steps: 14758 },
+    { date: '2018-04-29', steps: 549 },
+    { date: '2018-04-30', steps: 21 }
+  ];
+  const chart = new F2.Chart({
+    id: 'chart-tooltip',
+    width: 400,
+    height: 300,
+    plugins: Tooltip,
+    pixelRatio: 2
+  });
+  chart.source(data, {
+    date: {
+      tickCount: 3
+    }
+  });
+  chart.line().position('date*steps');
+
+  it('chart.tooltip() with xy crosshairs.', () => {
+    chart.tooltip({
+      crosshairsType: 'xy',
+      crosshairsStyle: {
+        lineDash: [ 2 ],
+        stroke: '#1890ff'
+      }
+    });
+
+    chart.render();
+    const point = chart.getPosition({ date: '2018-04-26', steps: 10586 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.get('tooltipController');
+    const tooltip = tooltipController.tooltip;
+    const { crosshairsShapeX, crosshairsShapeY } = tooltip;
+
+    expect(crosshairsShapeX).not.to.be.undefined;
+    expect(crosshairsShapeY).not.to.be.undefined;
+    expect(crosshairsShapeY.get('x')).to.equal(254.83888414171008);
+    expect(crosshairsShapeX.get('y')).to.equal(183.69416666666666);
+  });
+
+  it('show xTip and yTip', () => {
+    chart.tooltip({
+      showXTip: true,
+      showYTip: true,
+      crosshairsType: 'xy'
+    });
+    chart.repaint();
+    const point = chart.getPosition({ date: '2018-04-22', steps: 2515 });
+    chart.showTooltip(point);
+
+    const tooltipController = chart.get('tooltipController');
+    const tooltip = tooltipController.tooltip;
+    const { xTip, yTip } = tooltip;
+
+    expect(xTip).not.to.be.undefined;
+    expect(yTip).not.to.be.undefined;
+    expect(xTip.content).to.equal('2018-04-22');
+    expect(yTip.content).to.equal('2515');
+    expect(xTip.x).to.equal(106.08332316080728);
+    expect(xTip.y).to.equal(276.5);
+    expect(yTip.x).to.equal(31.95233154296875);
+    expect(yTip.y).to.equal(247.58958333333334);
+    chart.destroy();
     document.body.removeChild(canvas);
   });
 });

--- a/test/unit/plugin/tooltip-spec.js
+++ b/test/unit/plugin/tooltip-spec.js
@@ -18,6 +18,10 @@ canvas.style.top = 0;
 canvas.style.left = 0;
 document.body.appendChild(canvas);
 
+function snapEqual(v1, v2) {
+  return Math.abs(v1 - v2) < 0.01;
+}
+
 describe('Tooltip Plugin', function() {
   let chart;
   let tooltipController;
@@ -327,8 +331,8 @@ describe('Tooltip crosshairs', function() {
 
     expect(crosshairsShapeX).not.to.be.undefined;
     expect(crosshairsShapeY).not.to.be.undefined;
-    expect(crosshairsShapeY.get('x')).to.equal(254.83888414171008);
-    expect(crosshairsShapeX.get('y')).to.equal(183.69416666666666);
+    expect(snapEqual(crosshairsShapeY.get('x'), 254.83888414171008)).to.be.true;
+    expect(snapEqual(crosshairsShapeX.get('y'), 183.69416666666666)).to.be.true;
   });
 
   it('show xTip and yTip', () => {
@@ -349,10 +353,10 @@ describe('Tooltip crosshairs', function() {
     expect(yTip).not.to.be.undefined;
     expect(xTip.content).to.equal('2018-04-22');
     expect(yTip.content).to.equal('2515');
-    expect(xTip.x).to.equal(106.08332316080728);
+    expect(snapEqual(xTip.x, 106.08332316080728)).to.be.true;
     expect(xTip.y).to.equal(276.5);
-    expect(yTip.x).to.equal(31.95233154296875);
-    expect(yTip.y).to.equal(247.58958333333334);
+    expect(snapEqual(yTip.x, 31.95233154296875)).to.be.true;
+    expect(snapEqual(yTip.y, 247.58958333333334)).to.be.true;
     chart.destroy();
     document.body.removeChild(canvas);
   });


### PR DESCRIPTION
…support xTip and yTip display for tooltip. Closed #369.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
