### PR TITLE
增强浏览器环境的判断，修复ReactNative被误判

### DIFF
--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -56,7 +56,7 @@ DomUtil = {
   isWx: (typeof wx === 'object') && (typeof wx.getSystemInfoSync === 'function'),  // weixin miniprogram
   isMy: (typeof my === 'object') && (typeof my.getSystemInfoSync === 'function'), // ant miniprogram
   isNode: (typeof module !== 'undefined') && (typeof module.exports !== 'undefined'), // in node
-  isBrowser: (typeof window !== 'undefined') && (typeof window.document !== 'undefined'), // in browser
+  isBrowser: (typeof window !== 'undefined') && (typeof window.document !== 'undefined') && (typeof window.sessionStorage !== 'undefined'), // in browser
   getPixelRatio() {
     return window && window.devicePixelRatio || 1;
   },


### PR DESCRIPTION
ReactNative Version：0.55.4
f2 Version: 3.1.12

由于RN暂不支持babel7，所以只能使用3.1.x让RN暂时可以与Node环境一样可以渲染