### PR TITLE
fix(chart.render): delay scale sync after adjust

### DIFF
--- a/src/chart/chart.js
+++ b/src/chart/chart.js
@@ -530,9 +530,9 @@ class Chart extends Base {
 
     this._initGeoms(geoms); // init all geometry instances
 
-    this.get('syncY') && this._syncYScales();
-
     this._adjustScale(); // do some adjust for data
+
+    this.get('syncY') && this._syncYScales();
 
     Chart.plugins.notify(this, 'beforeGeomDraw');
     this._renderAxis();


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
The scale sync process should run after scale adjust. The adjust of scale will break the sync