### PR TITLE
fix(bbox.js): getBBoxFromArc方法对于整圆的判断错误，导致半圆弧的最小包围盒计算错误

### DIFF
--- a/src/graphic/util/bbox.js
+++ b/src/graphic/util/bbox.js
@@ -104,7 +104,7 @@ module.exports = {
   },
   getBBoxFromArc(x, y, r, startAngle, endAngle, anticlockwise) {
     const diff = Math.abs(startAngle - endAngle);
-    if (diff % Math.PI * 2 < 1e-4 && diff > 1e-4) {
+    if (diff % (Math.PI * 2) < 1e-4 && diff > 1e-4) {
       // Is a circle
       return {
         minX: x - r,


### PR DESCRIPTION
`var attrs = {x: 10, y: 10, r: 10, startAngle: 0, endAngle: Math.PI, anticlockwise: false}`的半圆弧，aabb包围盒应为`{minX: 0, minY:10, maxX: 20,maxY:  20}`,原计算方法的结果是`{minX: 0, minY:0, maxX: 20,maxY:  20}`


