### PR TITLE
chore: 发布时候babelrc & webpackrc & lintrc都带上了 这会影响工程本身

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "url": "https://github.com/antvis/f2/issues"
   },
   "files": [
-    "src",
     "lib",
     "build",
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/f2",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Charts for mobile visualization.",
   "keywords": [
     "f2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
   "bugs": {
     "url": "https://github.com/antvis/f2/issues"
   },
+  "files": [
+    "src",
+    "lib",
+    "build",
+    "dist",
+    "bundler"
+  ],
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",

--- a/src/global.js
+++ b/src/global.js
@@ -2,7 +2,7 @@ const Theme = require('./theme');
 const Util = require('./util/common');
 
 const Global = {
-  version: '3.4.0',
+  version: '3.4.1',
   scales: {},
   widthRatio: {
     column: 1 / 2,


### PR DESCRIPTION
chore: 发布时候babelrc & webpackrc & lintrc都带上了 这会影响工程本身

业务工程引入f2之后，本来用的babel6，结果f2的babelrc里写个依赖@babel/pre-env，还加了对应babel-plugin、这和业务工程本身冲突.

package.json的main直接到lib/index.js所以既然是编译物就不要把rc加进来污染业务工程.