### PR TITLE
fix: arc 与 sector 中 clockwise 参数改为 anticlockwise 以正确反映含义

### DIFF
--- a/src/graphic/shape/arc.js
+++ b/src/graphic/shape/arc.js
@@ -16,26 +16,26 @@ class Arc extends Shape {
       r: 0,
       startAngle: 0,
       endAngle: Math.PI * 2,
-      clockwise: false,
+      anticlockwise: false,
       lineWidth: 1
     };
   }
 
   createPath(context) {
     const attrs = this.get('attrs');
-    const { x, y, r, startAngle, endAngle, clockwise } = attrs;
+    const { x, y, r, startAngle, endAngle, anticlockwise } = attrs;
 
     context.beginPath();
     if (startAngle !== endAngle) {
-      context.arc(x, y, r, startAngle, endAngle, clockwise);
+      context.arc(x, y, r, startAngle, endAngle, anticlockwise);
     }
   }
 
   calculateBox() {
     const attrs = this.get('attrs');
-    const { x, y, r, startAngle, endAngle, clockwise } = attrs;
+    const { x, y, r, startAngle, endAngle, anticlockwise } = attrs;
 
-    return bbox.getBBoxFromArc(x, y, r, startAngle, endAngle, clockwise);
+    return bbox.getBBoxFromArc(x, y, r, startAngle, endAngle, anticlockwise);
   }
 }
 Shape.Arc = Arc;

--- a/src/graphic/shape/sector.js
+++ b/src/graphic/shape/sector.js
@@ -18,13 +18,13 @@ class Sector extends Shape {
       r0: 0,
       startAngle: 0,
       endAngle: Math.PI * 2,
-      clockwise: false
+      anticlockwise: false
     };
   }
 
   createPath(context) {
     const attrs = this.get('attrs');
-    const { x, y, startAngle, endAngle, r, r0, clockwise } = attrs;
+    const { x, y, startAngle, endAngle, r, r0, anticlockwise } = attrs;
     context.beginPath();
     const unitX = Math.cos(startAngle);
     const unitY = Math.sin(startAngle);
@@ -34,10 +34,10 @@ class Sector extends Shape {
 
     // 当扇形的角度非常小的时候，就不进行弧线的绘制；或者整个只有1个扇形时，会出现end<0的情况不绘制
     if (Math.abs(endAngle - startAngle) > 0.0001 || startAngle === 0 && endAngle < 0) {
-      context.arc(x, y, r, startAngle, endAngle, clockwise);
+      context.arc(x, y, r, startAngle, endAngle, anticlockwise);
       context.lineTo(Math.cos(endAngle) * r0 + x, Math.sin(endAngle) * r0 + y);
       if (r0 !== 0) {
-        context.arc(x, y, r0, endAngle, startAngle, !clockwise);
+        context.arc(x, y, r0, endAngle, startAngle, !anticlockwise);
       }
     }
     context.closePath();
@@ -45,9 +45,9 @@ class Sector extends Shape {
 
   calculateBox() {
     const attrs = this.get('attrs');
-    const { x, y, r, r0, startAngle, endAngle, clockwise } = attrs;
-    const outerBBox = bbox.getBBoxFromArc(x, y, r, startAngle, endAngle, clockwise);
-    const innerBBox = bbox.getBBoxFromArc(x, y, r0, startAngle, endAngle, clockwise);
+    const { x, y, r, r0, startAngle, endAngle, anticlockwise } = attrs;
+    const outerBBox = bbox.getBBoxFromArc(x, y, r, startAngle, endAngle, anticlockwise);
+    const innerBBox = bbox.getBBoxFromArc(x, y, r0, startAngle, endAngle, anticlockwise);
     return {
       minX: Math.min(outerBBox.minX, innerBBox.minX),
       minY: Math.min(outerBBox.minY, innerBBox.minY),

--- a/test/unit/graphic/group-spec.js
+++ b/test/unit/graphic/group-spec.js
@@ -65,7 +65,7 @@ describe('Group', function() {
       attrs: {
         startAngle: -Math.PI,
         endAngle: Math.PI / 2,
-        clockwise: false,
+        anticlockwise: false,
         x: 60,
         y: 60,
         r: 20,
@@ -84,7 +84,7 @@ describe('Group', function() {
       attrs: {
         startAngle: -Math.PI,
         endAngle: Math.PI / 2,
-        clockwise: false,
+        anticlockwise: false,
         x: 60,
         y: 60,
         r: 20,

--- a/test/unit/graphic/shape/arc-spec.js
+++ b/test/unit/graphic/shape/arc-spec.js
@@ -33,7 +33,7 @@ describe('Arc', function() {
     expect(arc.attr('r')).to.equal(50);
     expect(arc.attr('startAngle')).to.equal(0);
     expect(arc.attr('endAngle')).to.equal(Math.PI / 2);
-    expect(arc.attr('clockwise')).to.be.false;
+    expect(arc.attr('anticlockwise')).to.be.false;
     expect(arc.attr('lineWidth')).to.equal(2);
     expect(arc.attr('stroke')).to.equal('#18901f');
     expect(arc.get('canFill')).to.be.true;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (当前主分支本身包含11个 error，改动后并未增加新 error)
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
graphic/shape 中 Arc 和 Sector 两个类有表示角度方向的布尔值属性，目前名称为 clockwise, 但从使用看，它被直接传给`CanvasRenderingContext2D.arc()`:
```
...
context.beginPath();
context.arc(x, y, r, startAngle, endAngle, clockwise);
```
实际含义是“**逆时针**”，即当为 true 时表示逆时针，为 false 时表示顺时针。此外 BBox 对象的`getBBoxFromArc()`方法将对应形参命名为 anticlockwise，最好保持一致。

因此建议将此处的 clockwise 按实际含义改名为 anticlockwise ,以防今后的维护者困扰。

此参数仅为内部使用，[文档](https://www.yuque.com/antv/f2/api-g-shape#4wxvsx)中**并未**暴露给使用者，因此此改动不会导致 API 的变化。