### PR TITLE
fix: 修复Shape.Text 在设置 rotate 之后 Box 宽高不正确的问题

### DIFF
--- a/src/graphic/shape/text.js
+++ b/src/graphic/shape/text.js
@@ -1,5 +1,6 @@
 const Util = require('../../util/common');
 const Shape = require('../shape');
+const RectUtil = require('../util/rect');
 
 let textWidthCacheCounter = 0;
 let textWidthCache = {};
@@ -159,7 +160,7 @@ class Text extends Shape {
     let height = self._getTextHeight(); // attrs.height
 
     if (attrs.rotate) {
-      const rotatedBox = Util.Rect.calcRotatedBox({
+      const rotatedBox = RectUtil.calcRotatedBox({
         width,
         height,
         rotate: attrs.rotate

--- a/src/graphic/shape/text.js
+++ b/src/graphic/shape/text.js
@@ -162,12 +162,11 @@ class Text extends Shape {
       const rotatedBox = Util.Rect.calcRotatedBox({
         width,
         height,
-        rotate: attrs.rotate,
+        rotate: attrs.rotate
       });
       width = rotatedBox.width;
       height = rotatedBox.height;
     }
-    
     const point = {
       x,
       y: y - height

--- a/src/graphic/shape/text.js
+++ b/src/graphic/shape/text.js
@@ -147,7 +147,7 @@ class Text extends Shape {
     const self = this;
     const attrs = self._attrs.attrs;
     const { x, y, textAlign, textBaseline } = attrs;
-    const width = self._getTextWidth(); // attrs.width
+    let width = self._getTextWidth(); // attrs.width
     if (!width) {
       return {
         minX: x,
@@ -156,7 +156,18 @@ class Text extends Shape {
         maxY: y
       };
     }
-    const height = self._getTextHeight(); // attrs.height
+    let height = self._getTextHeight(); // attrs.height
+
+    if (attrs.rotate) {
+      const rotatedBox = Util.Rect.calcRotatedBox({
+        width,
+        height,
+        rotate: attrs.rotate,
+      });
+      width = rotatedBox.width;
+      height = rotatedBox.height;
+    }
+    
     const point = {
       x,
       y: y - height

--- a/src/graphic/util/rect.js
+++ b/src/graphic/util/rect.js
@@ -1,0 +1,12 @@
+const Rect = {
+  calcRotatedBox({ width, height, rotate }) {
+    const absRotate = Math.abs(rotate);
+    return {
+      width: Math.abs(width * Math.cos(absRotate) + height * Math.sin(absRotate)),
+      height: Math.abs(height * Math.cos(absRotate) + width * Math.sin(absRotate))
+    };
+  }
+};
+
+module.exports = Rect;
+

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -203,13 +203,13 @@ Util.Array = {
 };
 
 Util.Rect = {
-  calcRotatedBox({width, height, rotate}) {
+  calcRotatedBox({ width, height, rotate }) {
     return {
       width: Math.abs(width * Math.cos(rotate) + height * Math.sin(rotate)),
-      height: Math.abs(height * Math.cos(rotate) + width * Math.sin(rotate)),
-    }
+      height: Math.abs(height * Math.cos(rotate) + width * Math.sin(rotate))
+    };
   }
-}
+};
 
 Util.mix(Util, DomUtil);
 

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -204,9 +204,10 @@ Util.Array = {
 
 Util.Rect = {
   calcRotatedBox({ width, height, rotate }) {
+    const absRotate = Math.abs(rotate);
     return {
-      width: Math.abs(width * Math.cos(rotate) + height * Math.sin(rotate)),
-      height: Math.abs(height * Math.cos(rotate) + width * Math.sin(rotate))
+      width: Math.abs(width * Math.cos(absRotate) + height * Math.sin(absRotate)),
+      height: Math.abs(height * Math.cos(absRotate) + width * Math.sin(absRotate))
     };
   }
 };

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -202,6 +202,15 @@ Util.Array = {
   }
 };
 
+Util.Rect = {
+  calcRotatedBox({width, height, rotate}) {
+    return {
+      width: Math.abs(width * Math.cos(rotate) + height * Math.sin(rotate)),
+      height: Math.abs(height * Math.cos(rotate) + width * Math.sin(rotate)),
+    }
+  }
+}
+
 Util.mix(Util, DomUtil);
 
 module.exports = Util;

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -202,16 +202,6 @@ Util.Array = {
   }
 };
 
-Util.Rect = {
-  calcRotatedBox({ width, height, rotate }) {
-    const absRotate = Math.abs(rotate);
-    return {
-      width: Math.abs(width * Math.cos(absRotate) + height * Math.sin(absRotate)),
-      height: Math.abs(height * Math.cos(absRotate) + width * Math.sin(absRotate))
-    };
-  }
-};
-
 Util.mix(Util, DomUtil);
 
 module.exports = Util;

--- a/test/unit/graphic/shape/text-spec.js
+++ b/test/unit/graphic/shape/text-spec.js
@@ -168,6 +168,28 @@ describe('Text', function() {
     expect(bbox.width).to.equal(28.67578125);
     expect(bbox.height).to.equal(48);
     canvas.draw();
+  });
+
+  it('rotate', function() {
+    const text = new Text({
+      attrs: {
+        x: 100,
+        y: 50,
+        text: 'haha\nHello\nworld',
+        textAlign: 'end',
+        textBaseline: 'middle',
+        fontSize: 12,
+        lineHeight: 18,
+        lineWidth: 1,
+        rotate: Math.PI / 2
+      }
+    });
+    canvas.add(text);
+    // bbox
+    const bbox = text.getBBox();
+    expect(bbox.width).to.equal(48);
+    expect(bbox.height).to.equal(28.67578125);
+    canvas.draw();
     document.body.removeChild(dom);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fixes #724 