### PR TITLE
fix: 修复数据经过分组之后，没有任何数据的分组也参与绘图计算，尤其是在柱状图中，会占用宽度.

### DIFF
--- a/src/geom/base.js
+++ b/src/geom/base.js
@@ -71,7 +71,9 @@ class Geom extends Base {
       sortable: false,
       startOnZero: true,
       visible: true,
-      connectNulls: false
+      connectNulls: false,
+      // 是否丢弃没有值的分组。
+      ignoreEmptyGroup: false
     };
   }
 
@@ -196,7 +198,13 @@ class Geom extends Base {
     const self = this;
     const data = this.get('data');
     const dataArray = [];
-    const groupedArray = this._groupData(data);
+    let groupedArray = this._groupData(data);
+    if (this.get('ignoreEmptyGroup')) {
+      const yScale = this.getYScale();
+      groupedArray = groupedArray.filter(group =>
+        group.some(item => typeof item[yScale.field] !== 'undefined')
+      );
+    }
     for (let i = 0, len = groupedArray.length; i < len; i++) {
       const subData = groupedArray[i];
       const tempData = self._saveOrigin(subData);

--- a/test/unit/geom/geom-spec.js
+++ b/test/unit/geom/geom-spec.js
@@ -206,6 +206,36 @@ describe('test geoms', function() {
       expect(arr[1][0].c).equal('1');
     });
 
+    it('test group data with undefined values in group', function() {
+      geom.set('colDefs', {});
+      const data = [
+        // 相关数据
+        { a: 1, b: 1, c: '指标1' },
+        { a: 2, b: 2, c: '指标1' },
+        { a: 3, b: 3, c: '指标1' },
+        { a: 1, b: 2, c: '指标2' },
+        { a: 2, b: 3, c: '指标2' },
+        { a: 3, b: 4, c: '指标2' },
+        // 无关数据
+        { a: 1, b1: 3, c: '指标3' },
+        { a: 2, b1: 2, c: '指标3' },
+        { a: 3, b1: 1, c: '指标3' },
+        { a: 1, b1: 4, c: '指标4' },
+        { a: 2, b1: 3, c: '指标4' },
+        { a: 3, b1: 2, c: '指标4' }
+      ];
+      geom.set('data', data);
+      geom.position('a*b').color('c');
+      geom.init();
+      const dataArray = geom.get('dataArray');
+      expect(dataArray.length).equal(4);
+
+      geom.set('ignoreEmptyGroup', true);
+      geom.init();
+      const dataArray1 = geom.get('dataArray');
+      expect(dataArray1.length).equal(2);
+    });
+
     it('destroy', function() {
       geom.destroy();
       expect(geom.destroyed).equal(true);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

在 Gemo Base 中提供配置项 [Boolean] ignoreEmptyGroup, 初始值为 false, 向上兼容，在经过 _groupData 之后得到的分组数据，根据配置项，决定是否将不存在任何一个有 y 轴字段的数据分组剔除掉。

Fixes #716 