### PR TITLE
feat: 为 tooltip 的 xtip/ytip 增加 text 样式配置

### DIFF
--- a/src/component/tooltip.js
+++ b/src/component/tooltip.js
@@ -42,11 +42,23 @@ class Tooltip {
         fill: 'rgba(0, 0, 0, 0.65)',
         padding: [ 3, 5 ]
       },
+      xTipTextStyle: {
+        fontSize: 12,
+        fill: '#fff',
+        textAlign: 'center',
+        textBaseline: 'middle'
+      },
       yTip: null,
       yTipBackground: {
         radius: 1,
         fill: 'rgba(0, 0, 0, 0.65)',
         padding: [ 3, 5 ]
+      },
+      yTipTextStyle: {
+        fontSize: 12,
+        fill: '#fff',
+        textAlign: 'center',
+        textBaseline: 'middle'
       },
       /**
        * the style for tooltip container's background
@@ -86,10 +98,11 @@ class Tooltip {
       }
     }
     if (this.showXTip) {
-      const { xTipBackground } = this;
+      const { xTipBackground, xTipTextStyle } = this;
       const xTipBox = new TextBox({
         className: 'xTip',
         background: xTipBackground,
+        textStyle: xTipTextStyle,
         visible: false
       });
       frontPlot.add(xTipBox.container);
@@ -97,10 +110,11 @@ class Tooltip {
     }
 
     if (this.showYTip) {
-      const { yTipBackground } = this;
+      const { yTipBackground, yTipTextStyle } = this;
       const yTipBox = new TextBox({
         className: 'yTip',
         background: yTipBackground,
+        textStyle: yTipTextStyle,
         visible: false
       });
       frontPlot.add(yTipBox.container);

--- a/test/unit/graphic/group-spec.js
+++ b/test/unit/graphic/group-spec.js
@@ -323,6 +323,7 @@ describe('Group', function() {
         stroke: 'red',
         textBaseline: 'top',
         fontSize: 8,
+        fontFamily: 'Arial',
         lineHeight: 18,
         lineWidth: 1
       }

--- a/test/unit/graphic/shape/text-spec.js
+++ b/test/unit/graphic/shape/text-spec.js
@@ -71,7 +71,8 @@ describe('Text', function() {
         x: 30,
         y: 90,
         text: 'fill',
-        font: '20px Arial',
+        fontSize: 12,
+        fontFamily: 'Arial',
         fill: 'rgb(255, 0, 255)',
         stroke: '#8543E0',
         lineWidth: 1
@@ -94,6 +95,7 @@ describe('Text', function() {
     const text1 = new Text({
       attrs: {
         fontSize: 20,
+        fontFamily: 'Arial',
         text: 'fontSize',
         x: 10,
         y: 60,
@@ -102,7 +104,7 @@ describe('Text', function() {
       }
     });
     expect(text1.attr('fontSize')).to.equal(20);
-    expect(text1.attr('font')).to.equal('normal normal normal 20px sans-serif');
+    expect(text1.attr('font')).to.equal('normal normal normal 20px Arial');
     canvas.add(text1);
     // bbox
     const bbox = text1.getBBox();
@@ -154,6 +156,7 @@ describe('Text', function() {
         stroke: 'red',
         textBaseline: 'top',
         fontSize: 12,
+        fontFamily: 'Arial',
         lineHeight: 18,
         lineWidth: 1
       }
@@ -179,6 +182,7 @@ describe('Text', function() {
         textAlign: 'end',
         textBaseline: 'middle',
         fontSize: 12,
+        fontFamily: 'Arial',
         lineHeight: 18,
         lineWidth: 1,
         rotate: Math.PI / 2

--- a/test/unit/plugin/tooltip-spec.js
+++ b/test/unit/plugin/tooltip-spec.js
@@ -379,6 +379,9 @@ describe('Tooltip crosshairs', function() {
     chart.tooltip({
       showYTip: true,
       showXTip: true,
+      yTipTextStyle: {
+        fontFamily: 'Arial'
+      },
       yTip(val) {
         return parseInt(val);
       },
@@ -438,6 +441,12 @@ describe('Tooltip crosshairs', function() {
     chart.tooltip({
       showXTip: true,
       showYTip: true,
+      xTipTextStyle: {
+        fontFamily: 'Arial'
+      },
+      yTipTextStyle: {
+        fontFamily: 'Arial'
+      },
       showTooltipMarker: false,
       crosshairsType: 'xy',
       yTip(val) {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change

可以使用配置 tooltip 的 xtip/ytip 文字样式了

```
chart.tooltip({
  showXTip: true,
  showYTip: true,
  xTipTextStyle: {
    fontSize: 12,
    fill: '#fff',
  },
  yTipTextStyle: {
      fontSize: 12,
      fill: '#fff',
  },
})
```
