### PR TITLE
fix: 重绘时动画计算 startTime 错误

### DIFF
--- a/src/graphic/animate/animator.js
+++ b/src/graphic/animate/animator.js
@@ -1,4 +1,5 @@
 import * as Easing from './easing';
+import { clock } from '../util/clock';
 
 function plainArray(arr) {
   const result = [];
@@ -60,7 +61,7 @@ class Animator {
 
     const animInfo = {
       shape: this.shape,
-      startTime: this.timeline.time + delay,
+      startTime: this.timeline.time || clock.now() + delay,
       duration,
       easing
     };

--- a/src/graphic/animate/timeline.js
+++ b/src/graphic/animate/timeline.js
@@ -1,5 +1,5 @@
 import { requestAnimationFrame } from '../util/requestAnimationFrame';
-const clock = typeof performance === 'object' && performance.now ? performance : Date;
+import { clock } from '../util/clock';
 
 class Timeline {
   constructor() {

--- a/src/graphic/util/clock.js
+++ b/src/graphic/util/clock.js
@@ -1,0 +1,5 @@
+const clock = typeof performance === 'object' && performance.now ? performance : Date;
+
+export {
+  clock
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

使用 F2 的时候发现 3.7.7 修复完动画空执行之后有一个重绘后动画丢失的 bug。

具体复现情况请见 codesandbox: https://codesandbox.io/s/f2-animation-bug-demo-q88bl?file=/index.js

该 demo 是从官方 demo 修改的，异步触发 animation 必现。详细情况已经在 demo 的注释中给出。

当前提交的修复方法不知道会不会过于粗暴，辛苦 review，继续讨论。

简单修复，已经跑过测试。
