### PR TITLE
fix: attr 实例化时不判断数据相关的特征

### DIFF
--- a/packages/f2/src/attr/base.ts
+++ b/packages/f2/src/attr/base.ts
@@ -1,4 +1,4 @@
-import { Scale } from '@antv/scale';
+import { Scale, ScaleConfig } from '@antv/scale';
 import { mix, isFunction, isNil, isArray } from '@antv/util';
 import { values as arrayValues } from '../util/array';
 
@@ -19,7 +19,7 @@ class Base {
     }
   }
 
-  createScale(scale): Scale {
+  createScale(scaleConfig: ScaleConfig): Scale {
     return null;
   }
 

--- a/packages/f2/src/attr/category.ts
+++ b/packages/f2/src/attr/category.ts
@@ -1,9 +1,9 @@
-import { Category as CategoryScale } from '@antv/scale';
+import { Category as CategoryScale, ScaleConfig } from '@antv/scale';
 import Base from './base';
 
 class Category extends Base {
-  createScale(scale) {
-    return new CategoryScale(scale);
+  createScale(scaleConfig: ScaleConfig) {
+    return new CategoryScale(scaleConfig);
   }
 
   _mapping(value: any) {

--- a/packages/f2/src/attr/identity.ts
+++ b/packages/f2/src/attr/identity.ts
@@ -1,9 +1,9 @@
-import { Identity as IdentityScale } from '@antv/scale';
+import { Identity as IdentityScale, ScaleConfig } from '@antv/scale';
 import Base from './base';
 
 class Identity extends Base {
-  createScale(scale) {
-    return new IdentityScale(scale);
+  createScale(scaleConfig: ScaleConfig) {
+    return new IdentityScale(scaleConfig);
   }
 
   _mapping() {

--- a/packages/f2/src/attr/linear.ts
+++ b/packages/f2/src/attr/linear.ts
@@ -1,10 +1,10 @@
-import { Linear as LinearScale } from '@antv/scale';
+import { Linear as LinearScale, ScaleConfig } from '@antv/scale';
 import { isArray } from '@antv/util';
 import Base from './base';
 
 class Linear extends Base {
-  createScale(scale) {
-    return new LinearScale(scale);
+  createScale(scaleConfig: ScaleConfig) {
+    return new LinearScale(scaleConfig);
   }
 
   _mapping(value: any) {

--- a/packages/f2/src/controller/attr.ts
+++ b/packages/f2/src/controller/attr.ts
@@ -5,12 +5,13 @@ import {
   mix,
   isNil,
   isFunction,
-  isNumber,
 } from '@antv/util';
-import { Identity, Linear, Category } from '../attr';
+import * as Attrs from '../attr';
 import equal from '../base/equal';
 import { isArray } from '../util';
 import ScaleController from './scale';
+
+const { Identity, Linear, Category } = Attrs;
 
 type AttrOption = {
   field: string | Record<any, any>;
@@ -59,20 +60,20 @@ class AttrController {
       return new Identity(option);
     }
     const scale = this.scaleController.getScale(field);
-    const { values } = scale;
-    const firstValue = values[0];
 
     // identity
     if (scale && scale.type === 'identity') {
       return new Identity(option);
     }
 
+    
     // linear & category
-    const AttrConstructor = type
-      ? type
-      : typeof firstValue === 'number'
-      ? Linear
-      : Category;
+    let AttrConstructor = Attrs[type] || Category;
+
+    if(isFunction(type)) {
+      AttrConstructor = type;
+    }
+
     return new AttrConstructor({
       ...option,
       scale,

--- a/packages/f2/test/components/point/point.test.tsx
+++ b/packages/f2/test/components/point/point.test.tsx
@@ -78,13 +78,10 @@ describe.skip('Point Chart', () => {
           <Point
             x="x"
             y="y"
-            color={{
-              field: 'name',
-              values: ['#1890ff'],
-            }}
+            color="name"
             size={{
               field: 'z',
-              range: [10, 40, 60, 80],
+              range: [10, 20, 30, 40],
             }}
           />
         </Chart>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

* 创建 attr 的时候不应该去判断数据的特征来创建不同类型的attr。
* 兜底用 Category Attr，因为 x、y 已经强制设置为 Linear 了

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
