### PR TITLE
fix: attr映射逻辑优化

### DIFF
--- a/packages/f2/src/attr/base.ts
+++ b/packages/f2/src/attr/base.ts
@@ -15,7 +15,7 @@ class Base {
     const { scale, field, data } = this;
     if (!scale && data) {
       const values = arrayValues(data, field);
-      this.scale = this.createScale({ values });
+      this.scale = this.createScale({ values, field });
     }
   }
 

--- a/packages/f2/src/attr/linear.ts
+++ b/packages/f2/src/attr/linear.ts
@@ -1,22 +1,30 @@
 import { Linear as LinearScale, ScaleConfig } from '@antv/scale';
 import { isArray } from '@antv/util';
+import { interpolate } from 'd3-interpolate'
 import Base from './base';
 
 class Linear extends Base {
+  interpolate: any;
+
+  constructor(options) {
+    super(options);
+    const [min, max] = this.range;
+    this.interpolate = interpolate(min, max)
+  }
   createScale(scaleConfig: ScaleConfig) {
     return new LinearScale(scaleConfig);
   }
 
   _mapping(value: any) {
-    const { scale, range } = this;
-    const [min, max] = range;
+    const { scale, interpolate } = this;
 
     if (isArray(value)) {
       return value.map((v) => {
-        return min + (max - min) * scale.scale(v);
+        return interpolate(scale.scale(v));
       });
     }
-    return min + (max - min) * scale.scale(value);
+
+    return interpolate(scale.scale(value));
   }
 
   normalize(value: any) {

--- a/packages/f2/src/attr/linear.ts
+++ b/packages/f2/src/attr/linear.ts
@@ -8,11 +8,20 @@ class Linear extends Base {
 
   constructor(options) {
     super(options);
-    const [min, max] = this.range;
-    this.interpolate = interpolate(min, max)
+    this._updateInterpolate();
   }
   createScale(scaleConfig: ScaleConfig) {
     return new LinearScale(scaleConfig);
+  }
+
+  _updateInterpolate () {
+    const [min, max] = this.range;
+    this.interpolate = interpolate(min, max)
+  }
+
+  update(options) {
+    super.update(options);
+    this._updateInterpolate();
   }
 
   _mapping(value: any) {

--- a/packages/f2/src/components/axis/withAxis.tsx
+++ b/packages/f2/src/components/axis/withAxis.tsx
@@ -50,7 +50,7 @@ export default (View) => {
       };
     }
 
-    _getDimType() {
+    _getDimType(): 'x' | 'y' {
       const { props } = this;
       const { field, chart } = props;
       const xScales = chart.getXScales();

--- a/packages/f2/src/components/geometry/index.tsx
+++ b/packages/f2/src/components/geometry/index.tsx
@@ -1,4 +1,12 @@
-import { isFunction, each, upperFirst, mix, groupToMap, isObject } from '@antv/util';
+import {
+  isFunction,
+  each,
+  upperFirst,
+  mix,
+  groupToMap,
+  isObject,
+  includes
+} from '@antv/util';
 import Component from '../../base/component';
 import { group as arrayGroup, merge as arrayMerge, values } from '../../util/array';
 import * as Adjust from '../../adjust';
@@ -132,10 +140,11 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
 
   getDefaultAttrValues() {
     const attrRanges = this._getAttrRanges();
-    const { color, shape } = attrRanges;
+    const { color, shape, size } = attrRanges;
     return {
       color: color[0],
       shape: shape && shape[0],
+      size: size[0]
     };
   }
 
@@ -390,7 +399,12 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
         for (let k = 0; k < linearAttrsLength; k++) {
           const attrName = linearAttrs[k];
           const attr = attrs[attrName];
-          normalized[attrName] = attr.normalize(child[attr.field]);
+          // 分类属性的线性映射
+          if(includes(GROUP_ATTRS, attrName)) {
+            attrValues[attrName] = attr.mapping(child[attr.field]);
+          } else {
+            normalized[attrName] = attr.normalize(child[attr.field]);
+          }
         }
         const { x, y } = coord.convertPoint({
           x: normalized.x,

--- a/packages/f2/src/components/geometry/index.tsx
+++ b/packages/f2/src/components/geometry/index.tsx
@@ -1,12 +1,4 @@
-import {
-  isFunction,
-  each,
-  upperFirst,
-  mix,
-  groupToMap,
-  isObject,
-  includes
-} from '@antv/util';
+import { isFunction, each, upperFirst, mix, groupToMap, isObject, includes } from '@antv/util';
 import Component from '../../base/component';
 import { group as arrayGroup, merge as arrayMerge, values } from '../../util/array';
 import * as Adjust from '../../adjust';
@@ -18,10 +10,6 @@ import equal from '../../base/equal';
 
 // 保留原始数据的字段
 const FIELD_ORIGIN = 'origin';
-// 需要映射的属性名
-const ATTRS = ['x', 'y', 'color', 'size', 'shape'];
-// 分组处理的属性
-const GROUP_ATTRS = ['color', 'size', 'shape'];
 
 class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
   isGeometry = true;
@@ -51,10 +39,11 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
 
     const { chart } = props;
 
-    this.attrController = new AttrController(chart.scale);
+    const attrsRange = this._getThemeAttrsRange();
+    this.attrController = new AttrController(chart.scale, attrsRange);
     const { attrController } = this;
 
-    const attrOptions = this._getAttrOptions(props);
+    const attrOptions = attrController.getAttrOptions(props);
     attrController.create(attrOptions);
   }
 
@@ -63,8 +52,8 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
     const { data: nextData, adjust: nextAdjust } = nextProps;
     const { data: lastData, adjust: lastAdjust } = lastProps;
 
-    const nextAttrOptions = this._getAttrOptions(nextProps);
-    const lastAttrOptions = this._getAttrOptions(lastProps);
+    const nextAttrOptions = attrController.getAttrOptions(nextProps);
+    const lastAttrOptions = attrController.getAttrOptions(lastProps);
     if (!equal(nextAttrOptions, lastAttrOptions)) {
       attrController.update(nextAttrOptions);
       this.records = null;
@@ -93,37 +82,12 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
   }
 
   _createAttrs() {
-    const { attrController, props } = this;
-    const { chart } = props;
+    const { attrController } = this;
     attrController.attrs = {};
     this.attrs = attrController.getAttrs();
   }
 
-  _getAttrOptions(props) {
-    if (!props.x || !props.y) {
-      throw new Error('x, y are required !');
-    }
-    const options = {};
-    const ranges = this._getAttrRanges();
-    const { attrController } = this;
-    ATTRS.forEach((attrName) => {
-      if (!props[attrName]) return;
-      const option = attrController.parseOption(props[attrName]);
-      if (!option.range) {
-        option.range = ranges[attrName];
-      }
-      options[attrName] = option;
-    });
-    // @ts-ignore
-    const { x, y } = options;
-
-    // x, y 都是固定Linear 映射
-    x.type = Linear;
-    y.type = Linear;
-    return options;
-  }
-
-  _getAttrRanges() {
+  _getThemeAttrsRange() {
     const { context, props, geomType } = this;
     const { coord } = props;
     const { theme } = context;
@@ -138,16 +102,6 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
     };
   }
 
-  getDefaultAttrValues() {
-    const attrRanges = this._getAttrRanges();
-    const { color, shape, size } = attrRanges;
-    return {
-      color: color[0],
-      shape: shape && shape[0],
-      size: size[0]
-    };
-  }
-
   _adjustScales() {
     const { attrs, props, startOnZero: defaultStartOnZero } = this;
     const { chart, startOnZero = defaultStartOnZero } = props;
@@ -158,24 +112,9 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
     }
   }
 
-  _getGroupScales() {
-    const { attrs } = this;
-    const scales = [];
-    each(GROUP_ATTRS, (attrName) => {
-      const attr = attrs[attrName];
-      if (!attr) {
-        return;
-      }
-      const { scale } = attr;
-      if (scale && scale.isCategory && scales.indexOf(scale) === -1) {
-        scales.push(scale);
-      }
-    });
-    return scales;
-  }
-
   _groupData(data) {
-    const groupScales = this._getGroupScales();
+    const { attrController } = this;
+    const groupScales = attrController.getGroupScales();
     if (!groupScales.length) {
       return [{ children: data }];
     }
@@ -361,57 +300,59 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
     return shapeStyle;
   }
 
+  /**
+   * 数据映射到视图属性核心逻辑
+   * x、y 每个元素走 normalize 然后 convertPoint
+   * color、size、shape
+   *  如果是Linear，则每个元素 走 mapping
+   *  如果是Category/Identity 则第一个元素走 mapping
+   */
   _mapping(records) {
-    const { attrs, props } = this;
+    const { attrs, props, attrController } = this;
     const { coord } = props;
-    const attrNames = Object.keys(attrs);
-    const linearAttrs = [];
-    const nolinearAttrs = [];
-    attrNames.forEach((attrName) => {
-      if (attrs[attrName].constructor === Linear) {
-        linearAttrs.push(attrName);
-      } else {
-        nolinearAttrs.push(attrName);
-      }
-    });
 
-    const defaultAttrValues = this.getDefaultAttrValues();
+    const { linearAttrs, nonlinearAttrs } = attrController.getAttrsByLinear();
+    const defaultAttrValues = attrController.getDefaultAttrValues();
 
     for (let i = 0, len = records.length; i < len; i++) {
       const record = records[i];
       const { children } = record;
-      // 非线性映射只用映射第一项就可以了
       const attrValues = {
         ...defaultAttrValues,
       };
       const firstChild = children[0];
-      for (let k = 0, len = nolinearAttrs.length; k < len; k++) {
-        const attrName = nolinearAttrs[k];
+
+      // 非线性映射
+      for (let k = 0, len = nonlinearAttrs.length; k < len; k++) {
+        const attrName = nonlinearAttrs[k];
         const attr = attrs[attrName];
+        // 非线性映射只用映射第一项就可以了
         attrValues[attrName] = attr.mapping(firstChild[attr.field]);
       }
 
-      // 线性映射
-      const linearAttrsLength = linearAttrs.length;
+      // 线性属性映射
       for (let j = 0, childrenLen = children.length; j < childrenLen; j++) {
         const child = children[j];
         const normalized: any = {};
-        for (let k = 0; k < linearAttrsLength; k++) {
+        for (let k = 0; k < linearAttrs.length; k++) {
           const attrName = linearAttrs[k];
           const attr = attrs[attrName];
           // 分类属性的线性映射
-          if(includes(GROUP_ATTRS, attrName)) {
+          if (attrController.isGroupAttr(attrName)) {
             attrValues[attrName] = attr.mapping(child[attr.field]);
           } else {
             normalized[attrName] = attr.normalize(child[attr.field]);
           }
         }
+
         const { x, y } = coord.convertPoint({
           x: normalized.x,
           y: normalized.y,
         });
+
         // 获取shape的style
         const shape = this._getShapeStyle(attrValues.shape, child.origin);
+
         mix(child, attrValues, {
           normalized,
           x,

--- a/packages/f2/src/components/interval/util.ts
+++ b/packages/f2/src/components/interval/util.ts
@@ -1,34 +1,3 @@
-import { isArray } from '@antv/util';
-
-function convertRect({ x, y, size, y0 }) {
-  let xMin: number;
-  let xMax: number;
-  if (isArray(x)) {
-    xMin = x[0];
-    xMax = x[1];
-  } else {
-    xMin = x - size / 2;
-    xMax = x + size / 2;
-  }
-
-  let yMin: number;
-  let yMax: number;
-  if (isArray(y)) {
-    yMin = y[0];
-    yMax = y[1];
-  } else {
-    yMin = Math.min(y0, y);
-    yMax = Math.max(y0, y);
-  }
-
-  return {
-    xMin,
-    xMax,
-    yMin,
-    yMax,
-  };
-}
-
 function convertToPoints({ xMin, xMax, yMin, yMax }) {
   return [
     { x: xMin, y: yMin }, // tl
@@ -38,4 +7,4 @@ function convertToPoints({ xMin, xMax, yMin, yMax }) {
   ];
 }
 
-export { convertRect, convertToPoints };
+export { convertToPoints };

--- a/packages/f2/src/components/interval/withInterval.tsx
+++ b/packages/f2/src/components/interval/withInterval.tsx
@@ -67,8 +67,8 @@ export default (Views) => {
         for (let j = 0, len = children.length; j < len; j++) {
           const child = children[j];
           const { normalized } = child;
-          const { x, y, size = defaultSize } = normalized;
-          const rect = convertRect({ x, y, size, y0 });
+          const { x, y } = normalized;
+          const rect = convertRect({ x, y, y0, size: defaultSize, });
           mix(child, coord.convertRect(rect));
         }
       }

--- a/packages/f2/src/components/line/lineView.tsx
+++ b/packages/f2/src/components/line/lineView.tsx
@@ -105,9 +105,9 @@ export default (props: LineViewProps) => {
                     points: points.map((point) => {
                       return { x: point.x, y: point.y };
                     }),
+                    ...shape,
                     stroke: color,
                     lineWidth: size,
-                    ...shape,
                   }}
                   animation={{
                     update: {

--- a/packages/f2/src/components/line/withLine.tsx
+++ b/packages/f2/src/components/line/withLine.tsx
@@ -106,8 +106,8 @@ export default (View) => {
 
         record.children = splitPoints.map((points) => {
           const [topPoints, bottomPoints] = isArray(y)
-            ? this.splitPoints(points)
-            : [points, undefined];
+          ? this.splitPoints(points)
+          : [points, undefined];
           return {
             size,
             color,

--- a/packages/f2/src/components/point/pointView.tsx
+++ b/packages/f2/src/components/point/pointView.tsx
@@ -27,7 +27,7 @@ export default (props: any) => {
                     update: {
                       easing: 'linear',
                       duration: 450,
-                      property: ['x', 'y', 'r'],
+                      property: ['x', 'y', 'r', 'fill'],
                     },
                   }}
                 />

--- a/packages/f2/src/components/sunburst/withSunburst.tsx
+++ b/packages/f2/src/components/sunburst/withSunburst.tsx
@@ -65,10 +65,10 @@ export default (View): any => {
         const color = colorAttr.mapping(root.data[colorAttr.field]);
         node.color = color;
         const rect = coord.convertRect({
-          xMin: node.x0,
-          xMax: node.x1,
-          yMin: node.y0,
-          yMax: node.y1,
+          x: node.x0,
+          y: node.y1,
+          y0: node.y0,
+          size: node.x1 - node.x0,
         });
         mix(node, rect);
         // 递归处理

--- a/packages/f2/src/components/treemap/withTreemap.tsx
+++ b/packages/f2/src/components/treemap/withTreemap.tsx
@@ -31,7 +31,7 @@ export default (View): any => {
       const { data, value /* space = 0 */ } = props;
 
       const root = hierarchy({ children: data })
-        .sum(function (d) {
+        .sum(function(d) {
           return d[value];
         })
         .sort((a, b) => b[value] - a[value]);
@@ -53,10 +53,10 @@ export default (View): any => {
         const { data, x0, y0, x1, y1 } = item;
         const color = colorAttr.mapping(data[colorAttr.field]);
         const rect = coord.convertRect({
-          xMin: x0,
-          xMax: x1,
-          yMin: y0,
-          yMax: y1,
+          x: x0,
+          y: y1,
+          y0: y0,
+          size: x1 - x0,
         });
         return {
           key: data.key,

--- a/packages/f2/src/controller/attr.ts
+++ b/packages/f2/src/controller/attr.ts
@@ -44,7 +44,7 @@ class AttrController {
     this.options = {};
     this.attrs = {};
   }
-  
+
   parseOption(option: AttrOption, attrName: Attr) {
     if (!option) {
       return {
@@ -59,8 +59,8 @@ class AttrController {
       };
     }
 
-    if(isNumber(option)) {
-      if(attrName === 'size') {
+    if (isNumber(option)) {
+      if (attrName === 'size') {
         return {
           type: 'identity',
           field: option,
@@ -143,29 +143,22 @@ class AttrController {
       scale, // 默认使用数据字段的scale
     }
 
-    let AttrConstructor = Category;
+    // Attr的默认类型和scale类型保持一致
+    let AttrConstructor = scale.isLinear ? Linear : Category;
 
     // custom Attr Constructor
     if (isFunction(type)) {
       AttrConstructor = type;
     }
 
-    // Linear & Category
     if (isString(type)) {
       // Category 分类属性创建自己的scale，不使用数据字段的
       if (type === 'category' || !Attrs[upperFirst(type)]) {
         AttrConstructor = Category;
         delete attrOption.scale;
       } else {
-        // Linear
         AttrConstructor = Attrs[upperFirst(type)];
       }
-    }
-
-    // Unknown Attr type
-    if (isNil(type)) {
-      AttrConstructor = Category;
-      delete attrOption.scale;
     }
 
     return new AttrConstructor(attrOption);

--- a/packages/f2/src/controller/scale.ts
+++ b/packages/f2/src/controller/scale.ts
@@ -128,6 +128,10 @@ class ScaleController {
     this.scales = {};
   }
 
+  getData() {
+    return this.data;
+  }
+
   getScale(field: string): Scale {
     const { scales, options, data } = this;
 

--- a/packages/f2/src/theme.ts
+++ b/packages/f2/src/theme.ts
@@ -90,7 +90,7 @@ const Theme = {
   colors: ['#1890FF', '#2FC25B', '#FACC14', '#223273', '#8543E0', '#13C2C2', '#3436C7', '#F04864'],
   shapes: {
     line: ['line', 'dash', 'smooth'],
-    point: ['circle', 'hollowCircle'],
+    point: ['circle', 'hollowCircle', 'rect'],
     area: ['area', 'smooth'],
     interval: ['rect', 'pyramid', 'funnel'],
   },

--- a/packages/f2/test/components/axis/axis.test.tsx
+++ b/packages/f2/test/components/axis/axis.test.tsx
@@ -166,7 +166,6 @@ describe('Axis 轴', () => {
             x="Year"
             y="NumberNewMicroBrewery"
             color={{
-              // TODO: 这里颜色映射还有点问题
               field: 'NumberNewMicroBrewery',
               callback: function (val) {
                 if (val === 20) {
@@ -239,9 +238,6 @@ describe('Axis 轴', () => {
                 return numberToMoney(val);
               },
             },
-            Einwohner: {
-              type: 'category',
-            },
           }}
         >
           <Axis
@@ -267,9 +263,9 @@ describe('Axis 轴', () => {
             y="Anzahl Flüchtlinge"
             color="#F04864"
             size={{
+              type: 'linear',
               field: 'Einwohner',
-              // TODO:这里size好像映射反了
-              range: [1, 5, 10, 15],
+              range: [5, 20],
             }}
             style={{
               fillOpacity: 0.7,
@@ -524,7 +520,7 @@ describe('Axis 轴', () => {
         >
           <Axis field="percent" visible={false} />
           <Axis
-            field="value"
+            field="name"
             style={{
               grid: {
                 lineDash: null,
@@ -539,7 +535,7 @@ describe('Axis 轴', () => {
               },
             }}
           />
-          <Interval x="name" y="percent" color="#E5875B" />
+          <Interval x="name" y="percent" color={['percent', ['#E5875B', '#C2832B']]} />
         </Chart>
       </Canvas>
     );

--- a/packages/f2/test/components/geometry/attr.test.tsx
+++ b/packages/f2/test/components/geometry/attr.test.tsx
@@ -1,6 +1,6 @@
 import { jsx } from '../../../src';
 import { Polar, Rect } from '../../../src/coord';
-import { Canvas, Chart } from '../../../src';
+import { Canvas, Chart, Component } from '../../../src';
 import { Interval, Axis, Point, Line, Area } from '../../../src/components';
 import { createContext } from '../../util';
 
@@ -181,7 +181,6 @@ describe('Geometry - Attr', () => {
             y="sales"
             size={12}
             color={{
-              type: 'linear',
               field: 'sales',
               range: ['blue', 'red'],
             }}
@@ -191,7 +190,50 @@ describe('Geometry - Attr', () => {
     );
     // @ts-ignore
     const canvas = new type(props);
+
     canvas.render();
+  });
+  
+  it('数据更新后也更新值域', () => {
+    class InjectTestComponent extends Component {
+      didMount() {    
+        setTimeout(() => {
+          // expect: 这里播放动画
+          this.props.chart.setState({
+            zoomRange: [0, 0.99],
+          });
+        }, 1000);
+      }
+    }
+    const context = createContext('数据更新后也更新值域', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point
+            x="year"
+            y="sales"
+            size={12}
+            color={{
+              type: 'linear',
+              field: 'sales',
+              range: ['blue', 'red'],
+            }}
+          />
+          <InjectTestComponent />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+    setTimeout(() => {
+      props.children.props.children[2].props.color.range = ['red', 'blue'];
+      props.children.props.children[2].props.size = 24
+      canvas.update(props);
+    }, 300)
   });
   it('color = {{ type, field, callback }}', () => {
     const context = createContext('color = {{ type, field, callback }} 回调函数设置值域', {

--- a/packages/f2/test/components/geometry/attr.test.tsx
+++ b/packages/f2/test/components/geometry/attr.test.tsx
@@ -1,0 +1,543 @@
+import { jsx } from '../../../src';
+import { Polar, Rect } from '../../../src/coord';
+import { Canvas, Chart } from '../../../src';
+import { Interval, Axis, Point, Line, Area } from '../../../src/components';
+import { createContext } from '../../util';
+
+const data = [
+  {
+    year: '1951 年',
+    sales: 38,
+    type: 'companyA',
+  },
+  {
+    year: '1952 年',
+    sales: 52,
+    type: 'companyA',
+  },
+  {
+    year: '1956 年',
+    sales: 61,
+    type: 'companyA',
+  },
+  {
+    year: '1957 年',
+    sales: 145,
+    type: 'companyA',
+  },
+  {
+    year: '1958 年',
+    sales: 48,
+    type: 'companyA',
+  },
+  {
+    year: '1959 年',
+    sales: 38,
+    type: 'companyA',
+  },
+  {
+    year: '1960 年',
+    sales: 38,
+    type: 'companyA',
+  },
+  {
+    year: '1962 年',
+    sales: 38,
+    type: 'companyA',
+  },
+  {
+    year: '1951 年',
+    sales: 60,
+    type: 'companyB',
+  },
+  {
+    year: '1952 年',
+    sales: 72,
+    type: 'companyB',
+  },
+  {
+    year: '1956 年',
+    sales: 58,
+    type: 'companyB',
+  },
+  {
+    year: '1957 年',
+    sales: 112,
+    type: 'companyB',
+  },
+  {
+    year: '1958 年',
+    sales: 52,
+    type: 'companyB',
+  },
+  {
+    year: '1959 年',
+    sales: 22,
+    type: 'companyB',
+  },
+  {
+    year: '1960 年',
+    sales: 47,
+    type: 'companyB',
+  },
+  {
+    year: '1962 年',
+    sales: 35,
+    type: 'companyB',
+  },
+];
+
+describe('Geometry - Attr', () => {
+  /**
+   * Color Attr
+   * 如果接收一个参数，则可以是：
+   * 1. 映射至颜色属性的数据源字段名，如果数据源中不存在这个字段名的话，则按照常量进行解析，这个时候会使用 F2 默认提供的颜色。
+   * 2. 也可以直接指定某一个具体的颜色值 color，如 '#fff', 'white', 'l(0) 0:#ffffff 0.5:#7ec2f3 1:#1890ff' 等。
+   */
+  it('不传color', () => {
+    const context = createContext('不传color', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" shape="type" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('color = {value}', () => {
+    const context = createContext('color = {value} 传入一个颜色值', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" color="red" shape="type" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('color = {field}', () => {
+    const context = createContext('color = {field} 传入一个分类域', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" size={3} color="type" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('color = {{ field, range }}', () => {
+    const context = createContext('color = {{ field, range }} 传入分类域和值域', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point
+            x="year"
+            y="sales"
+            size={12}
+            color={{
+              field: 'type',
+              range: ['blue', 'red'],
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('color = {{ type, field, range }}', () => {
+    const context = createContext('color = {{ type, field, range }} 线性值域', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point
+            x="year"
+            y="sales"
+            size={12}
+            color={{
+              type: 'linear',
+              field: 'sales',
+              range: ['blue', 'red'],
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('color = {{ type, field, callback }}', () => {
+    const context = createContext('color = {{ type, field, callback }} 回调函数设置值域', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point
+            x="year"
+            y="sales"
+            size={12}
+            color={{
+              type: 'linear',
+              field: 'sales',
+              callback: (val) => {
+                if (val > 70) {
+                  return 'red';
+                }
+                return 'blue';
+              },
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('color = {[ field, colors ]} ', () => {
+    const context = createContext('color = {[ field, colors ]} 快捷设置', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point x="year" y="sales" size={12} color={['type', ['blue', 'red']]} />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+
+  /**
+   * Size Attr
+   * 如果接收一个参数，则可以是
+   * 1. 数字常量，代表不同shape的size（如point影响半径、line/area影响线的粗细，interval影响柱状图的宽度
+   * 2. 字段名，按字段的值做size大小的映射
+   */
+  it('不传size', () => {
+    const context = createContext('不传size', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Interval x="year" y="sales" color="type" adjust="dodge" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+
+  it('size = {value} 直接设置size', () => {
+    const context = createContext('size = {value} 直接设置size', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Interval x="year" y="sales" size={16} color="type" adjust="dodge" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+
+  it('size = {field}  用size大小来做分类', () => {
+    const context = createContext('size = {field}  用size大小来做分类', { width: '380px' });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          {/* 用size大小来做分类 */}
+          <Point x="year" y="sales" size="type" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+
+  it('size = {{ field, range }} 用size大小来做分类', () => {
+    const context = createContext('size = {{ field, range }} 用size大小来做分类', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Interval
+            x="year"
+            y="sales"
+            color="type"
+            adjust="dodge"
+            size={{
+              field: 'type',
+              range: [10, 20],
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('size = {{ type, field, range }} 数值越大，size越大', () => {
+    const context = createContext('size = {{ type, field, range }} 数值越大，size越大', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point
+            x="year"
+            y="sales"
+            size={{
+              // 数值越大，size越大
+              type: 'linear',
+              field: 'sales',
+              range: [0, 40],
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('size = {{ type, field, callback }} 数值越大，size越大', () => {
+    const context = createContext('size = {{ type, field, callback }} 数值越大，size越大', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point
+            x="year"
+            y="sales"
+            size={{
+              // 数值越大，size越大
+              type: 'linear', // 必须指定为连续型数据才能进行callback设置
+              field: 'sales',
+              callback: function(val) {
+                if (val > 50) {
+                  return 50;
+                }
+                return 10;
+              },
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+
+  it('size = {[ field, sizes ]} 用size大小来做分类', () => {
+    const context = createContext('size = {{ type, field, callback }} 用size大小来做分类', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Point x="year" y="sales" size={['type', [10, 20]]} />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+
+  /**
+   * Shape Attr
+   * 只支持接收一个参数，指定几何图像对象绘制的形状。
+   */
+  it('不传shape', () => {
+    const context = createContext('不传shape', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" color="type" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('shape = {shape}', () => {
+    const context = createContext('shape = {shape} 指定一种shape', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" color="type" shape="smooth" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('shape = {field}', () => {
+    const context = createContext('shape = {field} 指定一个分类字段', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" color="type" shape="type" />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('shape = {{ field, range }}', () => {
+    const context = createContext('shape = {{ field, range }} 指定字段和值域', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line
+            x="year"
+            y="sales"
+            color="type"
+            shape={{
+              field: 'type',
+              range: ['dash', 'smooth'],
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('shape = {{ type, field, callback }}', () => {
+    const context = createContext('shape = {{ type, field, callback }} 根据数据判断shape', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line
+            x="year"
+            y="sales"
+            size={'2px'}
+            shape={{
+              type: 'linear',
+              field: 'type',
+              callback: (type) => {
+                if (type === 'companyB') {
+                  return 'dash';
+                }
+                return 'line';
+              },
+            }}
+          />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+  it('shape = {[ field, shapes ]}', () => {
+    const context = createContext('shape = {[ field, shapes ]} 数组传入', {
+      width: '380px',
+    });
+
+    const { type, props } = (
+      <Canvas context={context}>
+        <Chart data={data}>
+          <Axis field="year" />
+          <Axis field="sales" />
+          <Line x="year" y="sales" size={'2px'} shape={['type', ['smooth', 'dash']]} />
+        </Chart>
+      </Canvas>
+    );
+    // @ts-ignore
+    const canvas = new type(props);
+    canvas.render();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

#### 1. size/color/shape Attr 下沉到 AttrController 判断和处理，方便不同的attr类型生成不同的attrOption。

#### 2. 支持分类属性进行线性映射（比如size/color，可以是线性映射）
![image](https://user-images.githubusercontent.com/19555547/141708637-31ef64d4-d185-4e13-aa04-b689add1712e.png)

#### 3. createAttr时，Attr类型判断修改，兜底为Category，并且不使用数据的scale

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
