### PR TITLE
fix: 雷达面积图坐标不一致问题

### DIFF
--- a/packages/f2/src/components/area/withArea.tsx
+++ b/packages/f2/src/components/area/withArea.tsx
@@ -5,6 +5,8 @@ export default (View) => {
     getDefaultCfg() {
       return {
         geomType: 'area',
+        // 面积图默认设为从0开始
+        startOnZero: true,
       };
     }
 

--- a/packages/f2/src/components/area/withArea.tsx
+++ b/packages/f2/src/components/area/withArea.tsx
@@ -1,4 +1,3 @@
-import { jsx } from '../../jsx';
 import withLine from '../line/withLine';
 
 export default (View) => {
@@ -6,8 +5,6 @@ export default (View) => {
     getDefaultCfg() {
       return {
         geomType: 'area',
-        // 面积图默认设为从0开始
-        startOnZero: true,
       };
     }
 

--- a/packages/f2/src/components/geometry/index.tsx
+++ b/packages/f2/src/components/geometry/index.tsx
@@ -76,9 +76,15 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
 
   willMount() {
     this._createAttrs();
+    if (!this.records) {
+      this._processData();
+    }
   }
   willUpdate() {
     this._createAttrs();
+    if (!this.records) {
+      this._processData();
+    }
   }
 
   didMount() {
@@ -370,9 +376,6 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
 
   // 数据映射
   mapping() {
-    if (!this.records) {
-      this._processData();
-    }
     const { records } = this;
     // 数据映射
     this._mapping(records);

--- a/packages/f2/test/components/area/area.test.tsx
+++ b/packages/f2/test/components/area/area.test.tsx
@@ -141,7 +141,7 @@ describe('面积图', () => {
           >
             <Axis field="month" />
             <Axis field="value" />
-            <Area x="month" y="value" />
+            <Area x="month" y="value" startOnZero={true} />
             <Line x="month" y="value" />
           </Chart>
         </Canvas>

--- a/packages/f2/test/components/line/radar.test.tsx
+++ b/packages/f2/test/components/line/radar.test.tsx
@@ -1,0 +1,118 @@
+/* @jsx React.createElement */
+import React from 'react';
+import { jsx, Canvas, Chart, Area } from '../../../src';
+import { Line, Point, Axis, Legend } from '../../../src/components';
+import { createContext } from '../../util';
+
+const data = [
+  {
+    item: 'Design',
+    user: '用户 A',
+    score: 70,
+  },
+  {
+    item: 'Design',
+    user: '用户 B',
+    score: 30,
+  },
+  {
+    item: 'Development',
+    user: '用户 A',
+    score: 60,
+  },
+  {
+    item: 'Development',
+    user: '用户 B',
+    score: 70,
+  },
+  {
+    item: 'Marketing',
+    user: '用户 A',
+    score: 50,
+  },
+  {
+    item: 'Marketing',
+    user: '用户 B',
+    score: 60,
+  },
+  {
+    item: 'Users',
+    user: '用户 A',
+    score: 40,
+  },
+  {
+    item: 'Users',
+    user: '用户 B',
+    score: 50,
+  },
+  {
+    item: 'Test',
+    user: '用户 A',
+    score: 60,
+  },
+  {
+    item: 'Test',
+    user: '用户 B',
+    score: 70,
+  },
+  {
+    item: 'Language',
+    user: '用户 A',
+    score: 70,
+  },
+  {
+    item: 'Language',
+    user: '用户 B',
+    score: 50,
+  },
+  {
+    item: 'Technology',
+    user: '用户 A',
+    score: 70,
+  },
+  {
+    item: 'Technology',
+    user: '用户 B',
+    score: 40,
+  },
+  {
+    item: 'Support',
+    user: '用户 A',
+    score: 60,
+  },
+  {
+    item: 'Support',
+    user: '用户 B',
+    score: 40,
+  },
+];
+
+describe('雷达图', () => {
+  describe('面积雷达图', () => {
+    it('面积雷达图图', () => {
+      const context = createContext();
+      const { offsetWidth } = document.body;
+      const height = offsetWidth * 0.75;
+      const { props } = (
+        <Canvas
+          context={context}
+          pixelRatio={window.devicePixelRatio}
+          width={offsetWidth}
+          height={height}
+        >
+          <Chart data={data} coord="polar">
+            <Axis field="item" />
+            <Axis field="score" />
+            <Line x="item" y="score" color="user" />
+            <Area x="item" y="score" color="user" />
+            <Point x="item" y="score" color="user" />
+            <Legend />
+          </Chart>
+        </Canvas>
+      );
+
+      const canvas = new Canvas(props);
+      canvas.render();
+    });
+  });
+});

--- a/packages/site/examples/area/area/demo/with-negative.js
+++ b/packages/site/examples/area/area/demo/with-negative.js
@@ -46,7 +46,7 @@ const { props } = (
     >
       <Axis field="month" />
       <Axis field="value" />
-      <Area x="month" y="value" />
+      <Area x="month" y="value" startOnZero={true} />
       <Line x="month" y="value" />
     </Chart>
   </Canvas>

--- a/packages/site/examples/radar/radar/demo/area.js
+++ b/packages/site/examples/radar/radar/demo/area.js
@@ -74,6 +74,14 @@ const { props } = (
     <Chart
       data={data}
 			coord='polar'
+      scale={{
+        score: {
+          min: 0,
+          max: 120,
+          nice: false,
+          tickCount: 4
+        }
+      }}
     >
       <Axis field="item" />
       <Axis field="score" />

--- a/packages/site/examples/radar/radar/demo/basic.js
+++ b/packages/site/examples/radar/radar/demo/basic.js
@@ -74,6 +74,14 @@ const { props } = (
     <Chart
       data={data}
 			coord='polar'
+      scale={{
+        score: {
+          min: 0,
+          max: 120,
+          nice: false,
+          tickCount: 4
+        }
+      }}
     >
       <Axis field="item" />
       <Axis field="score" />


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复：https://github.com/antvis/F2/projects/1#card-72944540
![image](https://user-images.githubusercontent.com/22373989/141935040-c6f54b13-432d-42e3-89e9-24672ba2263e.png)

原因：
- 面积图设置 `startOnZero` 为 `true`修改了 scale，scale 更新的时机不正确