### PR TITLE
fix: 饼图scale适配调整

### DIFF
--- a/packages/f2/src/components/geometry/index.tsx
+++ b/packages/f2/src/components/geometry/index.tsx
@@ -108,11 +108,17 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
 
   _adjustScales() {
     const { attrs, props, startOnZero: defaultStartOnZero } = this;
-    const { chart, startOnZero = defaultStartOnZero } = props;
+    const { chart, startOnZero = defaultStartOnZero, coord, adjust } = props;
+    const { isPolar, transposed } = coord;
     // 如果从 0 开始，只调整 y 轴 scale
     if (startOnZero) {
       const { y } = attrs;
       chart.scale.adjustStartZero(y.scale);
+    }
+    // 饼图的scale调整，关闭nice
+    if(isPolar && transposed && adjust === 'stack') {
+      const { y } = attrs;
+      chart.scale.adjustPieScale(y.scale);
     }
   }
 
@@ -245,7 +251,7 @@ class Geometry<T extends GeometryProps = GeometryProps> extends Component<T> {
     // 根据adjust分组
     const dataArray = this._adjustData(groupedArray);
 
-    // 主要是调整 y 轴是否从 0 开始
+    // scale适配调整，主要是调整 y 轴是否从 0 开始 以及 饼图
     this._adjustScales();
 
     this.dataArray = dataArray;

--- a/packages/f2/src/components/sunburst/withSunburst.tsx
+++ b/packages/f2/src/components/sunburst/withSunburst.tsx
@@ -65,11 +65,10 @@ export default (View): any => {
         const root = rootParent(node);
         const color = colorAttr.mapping(root.data[colorAttr.field]);
         node.color = color;
+        const { x0, x1, y0, y1 } = node;
         const rect = coord.convertRect({
-          x: node.x0,
-          y: node.y1,
-          y0: node.y0,
-          size: node.x1 - node.x0,
+          x: [x0, x1],
+          y: [y0, y1]
         });
         mix(node, rect);
         // 递归处理

--- a/packages/f2/src/components/treemap/withTreemap.tsx
+++ b/packages/f2/src/components/treemap/withTreemap.tsx
@@ -52,10 +52,8 @@ export default (View): any => {
         const { data, x0, y0, x1, y1 } = item;
         const color = colorAttr.mapping(data[colorAttr.field]);
         const rect = coord.convertRect({
-          x: x0,
-          y: y1,
-          y0: y0,
-          size: x1 - x0,
+          x: [x0, x1],
+          y: [y0, y1]
         });
         return {
           key: data.key,

--- a/packages/f2/src/controller/scale.ts
+++ b/packages/f2/src/controller/scale.ts
@@ -181,6 +181,20 @@ class ScaleController {
     }
   }
 
+  // 饼图下的scale调整
+  adjustPieScale(scale: Scale) {
+    const { options } = this;
+    const { field } = scale;
+    const option = options[field];
+
+    if (option && !isNil(option.nice)) {
+      return null;
+    }
+    scale.change({
+      nice: false
+    });
+  }
+
   // 获取scale 在 0点对位置的值
   getZeroValue(scale) {
     const { min, max } = scale;

--- a/packages/f2/src/coord/base.ts
+++ b/packages/f2/src/coord/base.ts
@@ -6,7 +6,7 @@ function transposedRect({ xMin, xMax, yMin, yMax }) {
   return { xMin: yMin, xMax: yMax, yMin: xMin, yMax: xMax };
 }
 
-function convertRect({ x, y, size, y0 }) {
+function convertRect({ x, y, size, y0 }: RectPoint) {
   let xMin: number;
   let xMax: number;
   if (isArray(x)) {
@@ -36,9 +36,11 @@ function convertRect({ x, y, size, y0 }) {
 }
 
 // 绘制矩形的关键点
-interface RectPoint extends Point {
-  y0: number;
-  size: number;
+interface RectPoint {
+  x: number | [number, number];
+  y: number | [number, number];
+  y0?: number;
+  size?: number;
 }
 
 /**

--- a/packages/f2/test/components/interval/example/pie.test.tsx
+++ b/packages/f2/test/components/interval/example/pie.test.tsx
@@ -8,32 +8,32 @@ import { createContext } from '../../../util';
 const data = [
   {
     name: '长津湖',
-    percent: 0.4,
+    percent: 10,
     a: '1',
   },
   {
     name: '我和我的父辈',
-    percent: 0.2,
+    percent: 20,
     a: '1',
   },
   {
     name: '失控玩家',
-    percent: 0.18,
+    percent: 30,
     a: '1',
   },
   {
     name: '宝可梦',
-    percent: 0.15,
+    percent: 40,
     a: '1',
   },
   {
     name: '峰爆',
-    percent: 0.05,
+    percent: 50,
     a: '1',
   },
   {
     name: '其他',
-    percent: 0.02,
+    percent: 60,
     a: '1',
   },
 ];
@@ -51,7 +51,6 @@ describe('饼图', () => {
             type: Polar,
             transposed: true,
           }}
-          scale={{}}
         >
           <Interval
             x="a"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->
![image](https://user-images.githubusercontent.com/19555547/141950053-c688701f-317d-47cf-adfc-676baf159ebb.png)

* 修复了饼图的scale.nice = true导致mapping不符合预期的问题
* 修复了 sunburst 和 treemap的坐标映射问题


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
