### PR TITLE
feat:轴支持offset配置

### DIFF
--- a/packages/f2/src/components/axis/rect/bottom.tsx
+++ b/packages/f2/src/components/axis/rect/bottom.tsx
@@ -3,8 +3,8 @@ import { RectProps } from '../types';
 import { TextAttrs } from '../../../types';
 
 export default (props: RectProps<'bottom'>) => {
-  const { ticks, coord, style, animation } = props;
-  const { left, right, bottom } = coord;
+  const { ticks, coord, style, animation, baseline } = props;
+  const { left, right } = coord;
   const { grid, tickLine, line, labelOffset, label } = style;
 
   return (
@@ -51,9 +51,9 @@ export default (props: RectProps<'bottom'>) => {
         <line
           attrs={{
             x1: left,
-            y1: bottom,
+            y1: baseline,
             x2: right,
-            y2: bottom,
+            y2: baseline,
             ...line,
           }}
         />

--- a/packages/f2/src/components/axis/rect/left.tsx
+++ b/packages/f2/src/components/axis/rect/left.tsx
@@ -2,8 +2,8 @@ import { jsx } from '../../../jsx';
 import { RectProps } from '../types';
 
 export default (props: RectProps) => {
-  const { ticks, coord, style, animation } = props;
-  const { left, top, bottom } = coord;
+  const { ticks, coord, style, animation, baseline } = props;
+  const { top, bottom } = coord;
   const { grid, tickLine, line, labelOffset, label } = style;
 
   return (
@@ -49,9 +49,9 @@ export default (props: RectProps) => {
       {line ? (
         <line
           attrs={{
-            x1: left,
+            x1: baseline,
             y1: top,
-            x2: left,
+            x2: baseline,
             y2: bottom,
             ...line,
           }}

--- a/packages/f2/src/components/axis/rect/right.tsx
+++ b/packages/f2/src/components/axis/rect/right.tsx
@@ -2,8 +2,8 @@ import { jsx } from '../../../jsx';
 import { RectProps } from '../types';
 
 export default (props: RectProps) => {
-  const { ticks, coord, style } = props;
-  const { top, right, bottom } = coord;
+  const { ticks, coord, style, baseline } = props;
+  const { top, bottom } = coord;
   const { grid, tickLine, line, labelOffset, label } = style;
 
   return (
@@ -47,9 +47,9 @@ export default (props: RectProps) => {
       {line ? (
         <line
           attrs={{
-            x1: right,
+            x1: baseline,
             y1: top,
-            x2: right,
+            x2: baseline,
             y2: bottom,
             ...line,
           }}

--- a/packages/f2/src/components/axis/rect/top.tsx
+++ b/packages/f2/src/components/axis/rect/top.tsx
@@ -2,8 +2,8 @@ import { jsx } from '../../../jsx';
 import { RectProps } from '../types';
 
 export default (props: RectProps) => {
-  const { ticks, coord, style } = props;
-  const { left, top, right } = coord;
+  const { ticks, coord, style, baseline } = props;
+  const { left, right } = coord;
   const { grid, tickLine, line, labelOffset, label } = style;
 
   return (
@@ -48,9 +48,9 @@ export default (props: RectProps) => {
         <line
           attrs={{
             x1: left,
-            y1: top,
+            y1: baseline,
             x2: right,
-            y2: top,
+            y2: baseline,
             ...line,
           }}
         />

--- a/packages/f2/src/components/axis/types.ts
+++ b/packages/f2/src/components/axis/types.ts
@@ -55,6 +55,9 @@ export interface RectProps<Type = void> {
   coord?: RectCord;
   style?: Style<Type>;
   animation?: any;
+  position?: 'right' | 'left' | 'top' | 'bottom';
+  dimType?: 'x' | 'y';
+  baseline?: number;
 }
 
 export interface PolarProps {
@@ -110,5 +113,9 @@ export interface AxisProps {
    * note: 作为 `<Chart />` 子元素时将自动注入
    */
   zoomRange?: [number, number];
+  /**
+   * 轴的位置偏移量，范围是[0~1]
+   */
+  offset?: number;
   [key: string]: any; // TODO
 }

--- a/packages/f2/src/components/axis/withAxis.tsx
+++ b/packages/f2/src/components/axis/withAxis.tsx
@@ -1,4 +1,4 @@
-import { deepMix, isFunction, mix, each, clone, isString, isNumber } from '@antv/util';
+import { deepMix, isFunction, mix, each, clone, isString, isNumber, isNil } from '@antv/util';
 import { jsx } from '../../jsx';
 import equal from '../../base/equal';
 import Component from '../../base/component';
@@ -167,6 +167,41 @@ export default (View) => {
       });
     }
 
+    _getBaseline() {
+      const { coord, offset, position } = this.props;
+      if (!position) {
+        return;
+      }
+      const dimType = this._getDimType();
+      const otherDim = dimType === 'x' ? 'y' : 'x';
+
+      if (isNil(offset)) {
+        let defaultBaseline = 0;
+        switch (position) {
+          case 'left':
+            defaultBaseline = coord.left;
+            break;
+          case 'top':
+            defaultBaseline = coord.top;
+            break;
+          case 'right':
+            defaultBaseline = coord.right;
+            break;
+          case 'bottom':
+            defaultBaseline = coord.bottom;
+            break;
+        }
+        return defaultBaseline;
+      }
+
+      const normalizedBaseline = {
+        [otherDim]: offset,
+        [dimType]: 0,
+      };
+
+      return coord.convertPoint(normalizedBaseline)[otherDim];
+    }
+
     // 主要是计算coord的布局
     updateCoord() {
       const { props } = this;
@@ -209,6 +244,7 @@ export default (View) => {
 
       const ticks = this.getTicks();
       const position = this._getPosition();
+      const baseline = this._getBaseline();
       const dimType = this._getDimType();
 
       return (
@@ -219,6 +255,7 @@ export default (View) => {
           coord={coord}
           position={position}
           dimType={dimType}
+          baseline={baseline}
         />
       );
     }

--- a/packages/f2/test/components/axis/axis.test.tsx
+++ b/packages/f2/test/components/axis/axis.test.tsx
@@ -545,4 +545,90 @@ describe('Axis 轴', () => {
     const canvas = new type(props);
     canvas.render();
   });
+
+  it('轴基准线', async () => {
+    const context = createContext('轴基准线 - 四象限图 - X/Y 都是线性数据');
+    const res = await fetch('https://gw.alipayobjects.com/os/antfincdn/6HodecuhvM/scatter.json');
+    const data = await res.json();
+    const { type, props } = (
+      <Canvas context={context} pixelRatio={window.devicePixelRatio}>
+        <Chart
+          data={data}
+          scale={{
+            height: { min: -220, max: 220 },
+            weight: { min: -120, max: 120 },
+          }}
+        >
+          <Axis
+            field="weight"
+            offset={0.5}
+            position="left"
+            style={{ line: { fill: '#000', stroke: '#000' } }}
+          />
+          <Axis
+            field="height"
+            offset={0.5}
+            position="bottom"
+            style={{ line: { fill: '#000', stroke: '#000' }, grid: (text) => {
+              if(text === '0') {
+                return {
+                  stroke: '#000'
+                }
+              }
+              return {}
+            } }}
+          />
+          <Point x="height" y="weight" color="#A3ABBF" size={10} />
+        </Chart>
+      </Canvas>
+    );
+
+    const canvas = new Canvas(props);
+    canvas.render();
+  });
+
+  it('轴基准线', async () => {
+    const context = createContext('轴基准线 - 四象限图 - X/Y 线性和非线性');
+    const data = [
+      { genre: 'Sports', sold: 275 },
+      { genre: 'Strategy', sold: 115 },
+      { genre: 'Action', sold: 120 },
+      { genre: 'Shooter', sold: 350 },
+      { genre: 'Other', sold: 150 }
+    ]
+    const { type, props } = (
+      <Canvas context={context} pixelRatio={window.devicePixelRatio}>
+        <Chart
+          data={data}
+          scale={{
+            sold: { min: -400, max: 400 },
+          }}
+        >
+          <Axis
+            field="sold"
+            offset={0.5}
+            position="left"
+            style={{ line: { fill: '#000', stroke: '#000' } }}
+          />
+          <Axis
+            field="genre"
+            offset={0.5}
+            position="bottom"
+            style={{ line: { fill: '#000', stroke: '#000' }, grid: (text) => {
+              if(text === 'Action') {
+                return {
+                  stroke: '#000'
+                }
+              }
+              return {}
+            } }}
+          />
+          <Interval x="genre" y="sold" color="genre" size={10} />
+        </Chart>
+      </Canvas>
+    );
+
+    const canvas = new Canvas(props);
+    canvas.render();
+  });
 });

--- a/packages/f2/test/components/interaction/pan.test.tsx
+++ b/packages/f2/test/components/interaction/pan.test.tsx
@@ -13,7 +13,7 @@ describe('Interaction 交互', () => {
     const res = await fetch('https://gw.alipayobjects.com/os/antfincdn/KbnoL5QgL0/index.json');
     const data = await res.json();
     const { props } = (
-      <Canvas context={context} pixelRatio={1}>
+      <Canvas context={context} pixelRatio={window.devicePixelRatio}>
         <Chart
           ref={chartRef}
           data={data}
@@ -57,7 +57,7 @@ describe('Interaction 交互', () => {
 
     await delay(100);
     expect(chart.coord.top).toBe(15);
-    expect(chart.coord.left).toBeCloseTo(41.96);
+    expect(chart.coord.left).toBeCloseTo(43.139);
     expect(chart.coord.bottom).toBeCloseTo(267.5);
   });
 });

--- a/packages/f2/test/components/point/point.test.tsx
+++ b/packages/f2/test/components/point/point.test.tsx
@@ -7,7 +7,7 @@ import { createContext } from '../../util';
 const url = 'https://gw.alipayobjects.com/os/antfincdn/6HodecuhvM/scatter.json';
 const url2 = 'https://gw.alipayobjects.com/os/antfincdn/aN68ysvGFa/index.json';
 
-describe.skip('Point Chart', () => {
+describe('Point Chart', () => {
   it('基础点图', async () => {
     const res = await fetch(url);
     const data = await res.json();
@@ -20,7 +20,7 @@ describe.skip('Point Chart', () => {
           ref={chartRef}
           data={data}
           coord={{
-            type: Rect,
+            type: 'rect',
           }}
           scale={{}}
         >
@@ -45,7 +45,7 @@ describe.skip('Point Chart', () => {
           ref={chartRef}
           data={data}
           coord={{
-            type: Polar,
+            type: 'polar',
           }}
           scale={{}}
         >
@@ -70,7 +70,7 @@ describe.skip('Point Chart', () => {
           ref={chartRef}
           data={data}
           coord={{
-            type: Rect,
+            type: 'rect',
           }}
           scale={{}}
         >


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->
Axis 组件支持 `offset` 配置，用于控制轴相对于画布的位置，控制的方式是设置scale
![image](https://user-images.githubusercontent.com/19555547/144990092-52107721-bde6-485b-a40b-b6c8d368b0f0.png)


```ts
export interface AxisProps {
  /**
   * 轴的位置偏移量，范围是[0~1]
   */
  offset?: number;
}

```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
