### PR TITLE
fix: 修复 legend maxItemWidth 计算错误

### DIFF
--- a/packages/f2/src/components/legend/withLegend.tsx
+++ b/packages/f2/src/components/legend/withLegend.tsx
@@ -71,6 +71,25 @@ export default (View) => {
       };
     }
 
+    willMount() {
+      this._initItems();
+      const { props } = this;
+      const shape = renderShape(this, this.render(), false);
+      const { height, width } = shape.get('attrs');
+
+      const { position = 'top', chart } = props;
+      const isVertical = position === 'left' || position === 'right';
+      if (!isVertical) {
+        chart.layoutCoord(position, { width, height });
+        shape.remove();
+        return;
+      }
+      const maxItemWidth = this.getMaxItemWidth(shape);
+      shape.remove();
+      this.maxItemWidth = maxItemWidth;
+      chart.layoutCoord(position, { width: maxItemWidth, height });
+    }
+
     didMount() {
       this._initEvent();
     }
@@ -103,7 +122,8 @@ export default (View) => {
     }
 
     getItems() {
-      return this.state.items;
+      const { items } = this.state;
+      return items?.length ? items : (this.getOriginItems() || []);
     }
 
     setItems(items) {
@@ -126,24 +146,6 @@ export default (View) => {
         }
       });
       return maxItemWidth;
-    }
-
-    willMount() {
-      this._initItems();
-      const { props } = this;
-      const shape = renderShape(this, this.render(), false);
-      const { height, width } = shape.get('attrs');
-
-      const { position = 'top', chart } = props;
-      const isVertical = position === 'left' || position === 'right';
-      if (!isVertical) {
-        chart.layoutCoord(position, { width, height });
-        return;
-      }
-      const maxItemWidth = this.getMaxItemWidth(shape);
-      this.maxItemWidth = maxItemWidth;
-      shape.remove();
-      chart.layoutCoord(position, { width: maxItemWidth, height });
     }
 
     render() {

--- a/packages/f2/test/components/legend/legend.test.tsx
+++ b/packages/f2/test/components/legend/legend.test.tsx
@@ -32,6 +32,7 @@ describe('图例', () => {
               <Tooltip showCrosshairs snap />
               <Legend
                 position="bottom"
+                // position="left"
                 marker="square"
                 // 自定义图例样式
                 style={{


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

两个问题：
- willMount 期间手动触发 render 时拿到的 this.state.items 为空数组，导致计算出来的 width 为 0
- isVertical = true 时没有 remove 掉用于计算时渲染的 shape
