### PR TITLE
fix: attr scale

### DIFF
--- a/packages/f2/src/controller/attr.ts
+++ b/packages/f2/src/controller/attr.ts
@@ -147,7 +147,11 @@ class AttrController {
       // Category 分类属性创建自己的scale，不使用数据字段的
       if (type === 'category' || !Attrs[upperFirst(type)]) {
         AttrConstructor = Category;
-        delete attrOption.scale;
+        const { scale } = attrOption;
+        // 如果原本的 scale.type 为 cat，则直接复用之前的 scale
+        if (scale.type !== 'cat') {
+          delete attrOption.scale;
+        }
       } else {
         AttrConstructor = Attrs[upperFirst(type)];
       }

--- a/packages/f2/test/components/line/line.test.tsx
+++ b/packages/f2/test/components/line/line.test.tsx
@@ -488,7 +488,12 @@ describe('折线图', () => {
                 coord={{
                   type: Rect,
                 }}
-                scale={{}}
+                scale={{
+                  type: {
+                    type: 'cat',
+                    values: ['金属', '农副产品', '能源'],
+                  },
+                }}
               >
                 <Axis
                   field="date"
@@ -498,7 +503,16 @@ describe('折线图', () => {
                   }}
                 />
                 <Axis field="value" tickCount={5} />
-                <Line ref={lineRef} x="date" y="value" lineWidth="4px" color="type" shape="type" />
+                <Line
+                  ref={lineRef}
+                  x="date"
+                  y="value"
+                  lineWidth="4px"
+                  // color={{
+                  //   field: 'type',
+                  // }}
+                  color="type"
+                />
                 <Tooltip
                   showCrosshairs
                   crosshairsType="xy"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

##### 问题
- 当 attr 的 type 为 category 时，会删去当前的 scale，没有保存之前 scale 上的配置

##### 具体复现步骤
见 http://f2-next.antv.vision/zh/examples/line/multiple#series ，传入 scale
``` js
{
  type: {
      values: ['金属', '农副产品', '能源'],
      formatter: (v) => `_${v}_`
  }
}
```
##### 期待
![image](https://user-images.githubusercontent.com/22373989/146168030-0fffdeaf-17bd-4b02-a8f3-1543e6c00776.png)

##### 实际
Legend 更新不会生效
![image](https://user-images.githubusercontent.com/22373989/146168220-f372abcd-ac39-4a31-ad56-e136f5b5002b.png)

