### PR TITLE
fix: Component Render 返回类型

### DIFF
--- a/packages/f2/src/base/component.ts
+++ b/packages/f2/src/base/component.ts
@@ -30,7 +30,7 @@ class Component<T = any> {
   willReceiveProps(_props: T) {}
   willUpdate() {}
   didUpdate() {}
-  render() {
+  render(): JSX.Element | null {
     return null;
   }
   didUnmount() {}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->
Component render 返回类型支持null
![image](https://user-images.githubusercontent.com/19555547/149136159-32332aaf-c4f9-438b-895c-690f478c2b05.png)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
