### PR TITLE
fix: 导出类型

### DIFF
--- a/packages/f2/src/components/axis/types.d.ts
+++ b/packages/f2/src/components/axis/types.d.ts
@@ -112,3 +112,8 @@ export interface AxisProps {
   zoomRange?: [number, number];
   [key: string]: any; // TODO
 }
+
+export namespace AxisTypes {
+  export type Props = AxisProps
+}
+

--- a/packages/f2/src/index.ts
+++ b/packages/f2/src/index.ts
@@ -1,4 +1,5 @@
-export * from './types';
+import type * as Types from './types'
+export { Types };
 // import * as attr from './attr';
 // import * as util from './util';
 import Children from './children';

--- a/packages/f2/src/types.ts
+++ b/packages/f2/src/types.ts
@@ -1,3 +1,4 @@
+import { AxisTypes } from './components/axis/types';
 import type {
   Point,
   CircleAttrs as CircleGraphicAttrs,
@@ -41,6 +42,8 @@ interface PxPoint {
   x: px;
   y: px;
 }
+
+export type { AxisTypes }
 
 type SupportPx<T> = {
   [k in keyof T]:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

将 types.ts 里定义的类型都挂载到 `Types` 的命名空间下，之前的写法是没办法在上层消费 types.ts 里定义的类型。

现在可以通过如下的方式消费类型：
```tsx
import type { Types } from '@antv/f2'

export interface PolarAxisProps extends Types.AxisTypes.Props {
   ... 
}

```

相关参考：https://tipsfordev.com/export-all-types-and-just-types-from-typescript-module

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
