### PR TITLE
feat: Canvas 新增 renderShapeOnce 私有方法

### DIFF
--- a/packages/f2/src/base/diff.ts
+++ b/packages/f2/src/base/diff.ts
@@ -298,4 +298,4 @@ function renderChildren(parent: Component, nextChildren, lastChildren) {
   return nextChildren;
 }
 
-export { renderChildren, diff, renderComponent, renderShape };
+export { renderChildren, diff, renderComponent, renderShape, createComponent };

--- a/packages/f2/src/canvas/index.ts
+++ b/packages/f2/src/canvas/index.ts
@@ -7,7 +7,7 @@ import Animation from './animation';
 import { px2hd as defaultPx2hd } from '../util';
 import { createUpdater } from '../base/updater';
 import defaultTheme from '../theme';
-import { renderChildren, renderComponent } from '../base/diff';
+import { renderChildren, renderComponent, createComponent, renderShape } from '../base/diff';
 import EE from '@antv/event-emitter';
 
 interface ChartProps {
@@ -108,6 +108,7 @@ class Canvas extends Component<ChartProps> {
       theme,
       px2hd,
       measureText: measureText(canvas, px2hd),
+      renderShapeOnce: (element: JSX.Element)=> this.renderShapeOnce(this, element),
     };
 
     // 动画模块
@@ -165,6 +166,16 @@ class Canvas extends Component<ChartProps> {
     renderChildren(this, nextChildren, lastChildren);
     this.draw();
     return null;
+  }
+
+  private renderShapeOnce(component, element: JSX.Element) {
+    const Component = createComponent(component, element);
+    const shape = renderShape(Component, Component.render(), false)
+    setTimeout(() => {
+      // 从 canvas group 中移除掉
+      shape.remove();
+    }, 0)
+    return shape;
   }
 
   destroy() {

--- a/packages/f2/src/canvas/index.ts
+++ b/packages/f2/src/canvas/index.ts
@@ -108,7 +108,7 @@ class Canvas extends Component<ChartProps> {
       theme,
       px2hd,
       measureText: measureText(canvas, px2hd),
-      renderShapeOnce: (element: JSX.Element)=> this.renderShapeOnce(this, element),
+      renderShapeOnce: (element: JSX.Element) => this.renderShapeOnce(this, element),
     };
 
     // 动画模块
@@ -171,10 +171,8 @@ class Canvas extends Component<ChartProps> {
   private renderShapeOnce(component, element: JSX.Element) {
     const Component = createComponent(component, element);
     const shape = renderShape(Component, Component.render(), false)
-    setTimeout(() => {
-      // 从 canvas group 中移除掉
-      shape.remove();
-    }, 0)
+    // 从 canvas group 中移除掉
+    shape.remove();
     return shape;
   }
 

--- a/packages/f2/src/components/axis/rect/bottom.tsx
+++ b/packages/f2/src/components/axis/rect/bottom.tsx
@@ -1,6 +1,7 @@
 import { jsx } from '../../../jsx';
 import { RectProps } from '../types';
 import { TextAttrs } from '../../../types';
+import { px2hd } from '../../../util'
 
 export default (props: RectProps<'bottom'>) => {
   const { ticks, coord, style, animation } = props;
@@ -40,7 +41,7 @@ export default (props: RectProps<'bottom'>) => {
                   x1: start.x,
                   y1: start.y,
                   x2: start.x,
-                  y2: start.y + tickLine.length,
+                  y2: start.y + px2hd(tickLine.length),
                   ...tickLine,
                 }}
               />

--- a/packages/f2/src/types.ts
+++ b/packages/f2/src/types.ts
@@ -45,6 +45,8 @@ interface PxPoint {
 
 export type { AxisTypes }
 
+export * from '@antv/scale'
+
 type SupportPx<T> = {
   [k in keyof T]:
     k extends PX_FIELD_NAME ?

--- a/packages/f2/test/components/canvas/canvas.test.tsx
+++ b/packages/f2/test/components/canvas/canvas.test.tsx
@@ -44,4 +44,37 @@ describe('Canvas', () => {
     expect(rect._attrs.type).toBe('rect');
     expect(rect._attrs.attrs.fill).toBe('red');
   });
+
+  it('renderShapeOnce - Class Component', () => {
+    const { props } = <Canvas context={context} pixelRatio={1}></Canvas>;
+
+    const canvas = new Canvas(props);
+    console.log('canvas: ', canvas.context);
+    const shape = canvas.context.renderShapeOnce(<Test />);
+
+    expect(shape._attrs.attrs.height).toBe(10);
+  });
+
+  it('renderShapeOnce - Function Component', () => {
+    const { props } = <Canvas context={context} pixelRatio={1}></Canvas>;
+    const Test = () => {
+      return (
+        <rect
+          attrs={{
+            x: 10,
+            y: 10,
+            width: 10,
+            height: 10,
+            fill: 'red',
+          }}
+        />
+      );
+    };
+
+    const canvas = new Canvas(props);
+    const shape = canvas.context.renderShapeOnce(<Test />);
+    console.log('shape: ', shape);
+
+    expect(shape._attrs.attrs.height).toBe(10);
+  });
 });

--- a/packages/f2/test/components/canvas/canvas.test.tsx
+++ b/packages/f2/test/components/canvas/canvas.test.tsx
@@ -49,7 +49,6 @@ describe('Canvas', () => {
     const { props } = <Canvas context={context} pixelRatio={1}></Canvas>;
 
     const canvas = new Canvas(props);
-    console.log('canvas: ', canvas.context);
     const shape = canvas.context.renderShapeOnce(<Test />);
 
     expect(shape._attrs.attrs.height).toBe(10);
@@ -73,7 +72,6 @@ describe('Canvas', () => {
 
     const canvas = new Canvas(props);
     const shape = canvas.context.renderShapeOnce(<Test />);
-    console.log('shape: ', shape);
 
     expect(shape._attrs.attrs.height).toBe(10);
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

基于F2的组件库有时候需要提前渲染某些组件，获取到对应的包围盒（宽、高属性）并进行一些针对性的渲染，所以需要透出单独渲染Component的方法。

使用方式如下：
```js
 // 这里可以是Class Component 也可以是 Function Component
    const Test = (props) => <text attrs={{
      fill: '#000',
      text: 'hello world'
    }} />
    const testShape = this.context.renderShapeOnce(<Test/>)
    console.log('debug bbox',testShape.getBBox()); // {minX: 0, minY: 0, maxX: 58.427886962890625, maxY: 12, x: 0, …}
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
