### PR TITLE
fix: 修复 polyline 只有1个点时，getbbox 计算不对

### DIFF
--- a/src/graphic/engine/shape/polyline.js
+++ b/src/graphic/engine/shape/polyline.js
@@ -68,6 +68,9 @@ class Polyline extends Shape {
     const { points, smooth, lineWidth } = attrs;
 
     const filteredPoints = _filterPoints(points);
+    if (filteredPoints.length <= 1) {
+      return getBBoxFromPoints(filteredPoints, lineWidth);
+    }
     if (smooth) {
       const newPoints = [];
       const constaint = [

--- a/test/unit/graphic/shape/polyline-spec.js
+++ b/test/unit/graphic/shape/polyline-spec.js
@@ -95,6 +95,26 @@ describe('Smooth Polyline', function() {
     expect(snapEqual(bbox.height, 35.502917125608604)).to.be.true;
   });
 
+  it('getBBox 1 point', function() {
+    const line = new Polyline({
+      attrs: {
+        points: [
+          { x: 10, y: 100 }
+        ],
+        lineWidth: 4,
+        strokeStyle: '#223273',
+        lineCap: 'round',
+        smooth: true
+      }
+    });
+    const bbox = line.getBBox();
+    expect(bbox.x).to.equal(8);
+    expect(bbox.y).to.equal(98);
+    expect(bbox.width).to.equal(4);
+    expect(bbox.height).to.equal(4);
+  });
+
+
   it('destroy', function() {
     line.destroy();
     expect(canvas.get('children').length).to.equal(0);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
