### PR TITLE
feat(@antv/f2-vue): 增强对自定义图形及自定义图表组件的JSX编译支持

### DIFF
--- a/packages/site/docs/tutorial/vue.zh.md
+++ b/packages/site/docs/tutorial/vue.zh.md
@@ -14,130 +14,133 @@ npm install @antv/f2 --save
 npm install @antv/f2-vue --save
 ```
 
-### 2. 配置 F2 的 JSX 编译
-
-```bash
-npm install @babel/plugin-transform-react-jsx --save-dev
-```
-
-打开 `vue.config.js` 添加如下代码
-
-```js
-{
-  chainWebpack: (config) => {
-    config.module
-      .rule('F2')
-      .test(/\.jsx$/)
-      .use('babel')
-      .loader('babel-loader')
-      .options({
-        plugins: [
-          [
-            '@babel/plugin-transform-react-jsx',
-            {
-              runtime: 'automatic',
-              importSource: '@antv/f2',
-            },
-          ],
-        ],
-      })
-      .end();
-  },
-}
-```
-
-### 3. Vite 中配置
-
-```bash
-npm install @rollup/plugin-babel --save-dev
-npm install @babel/plugin-transform-react-jsx --save-dev
-```
-
-打开 `vite.config.js` 添加如下配置
-
-```js
-import vue from '@vitejs/plugin-vue';
-import vueJsx from '@vitejs/plugin-vue-jsx';
-import { babel } from '@rollup/plugin-babel';
-
-export default defineConfig({
-  plugins: [
-    babel({
-      plugins: [
-        [
-          '@babel/plugin-transform-react-jsx',
-          {
-            runtime: 'automatic',
-            importSource: '@antv/f2',
-          },
-        ],
-      ],
-    }),
-    vue(),
-    vueJsx(),
-  ],
-});
-```
-
-### 4. 使用示例
+### 2. 使用示例
 
 ```vue
-<script>
-import { toRaw } from 'vue';
+<template>
+  <div class="container">
+    <Canvas>
+      <Chart :data="data">
+        <Axis field="genre" />
+        <Axis field="sold" />
+        <Tooltip :showTooltipMarker="true" />
+        <Interval x="genre" y="sold" color="genre" />
+      </Chart>
+    </Canvas>
+  </div>
+</template>
+<script setup>
 import Canvas from '@antv/f2-vue';
-import { Chart, Interval, Axis } from '@antv/f2';
+import { Chart, Interval, Axis, Tooltip } from '@antv/f2';
 
-const data1 = [
+const data = [
   { genre: 'Sports', sold: 275 },
   { genre: 'Strategy', sold: 115 },
   { genre: 'Action', sold: 120 },
   { genre: 'Shooter', sold: 350 },
   { genre: 'Other', sold: 150 },
 ];
-const data2 = [
-  { genre: 'Sports', sold: 275 },
-  { genre: 'Strategy', sold: 115 },
-  { genre: 'Action', sold: 20 },
-  { genre: 'Shooter', sold: 50 },
-  { genre: 'Other', sold: 50 },
-];
-export default {
-  name: 'App',
-  data() {
-    return {
-      year: '2021',
-      chartData: data1,
-    };
-  },
-  mounted() {
-    setTimeout(() => {
-      this.year = '2022';
-      this.chartData = data2;
-    }, 1000);
-  },
-  render() {
-    const { year, chartData } = this;
-    return (
-      <div className="container">
-        <Canvas pixelRatio={window.devicePixelRatio}>
-          <Chart data={toRaw(chartData)}>
-            <Axis field="genre" />
-            <Axis field="sold" />
-            <Interval x="genre" y="sold" color="genre" />
-          </Chart>
-        </Canvas>
-      </div>
-    );
-  },
-};
 </script>
-
 <style>
 .container {
   width: 500px;
   height: 300px;
 }
 </style>
+```
+
+### 3. 自定义 View
+在Vue中，[自定义View](advanced/custom-view)的高阶组件（HOC）需要从`@antv/f2-vue`中引入，即：`import { withXXX } from "@antv/f2-vue"`。
+
+以下是自定义图例的示例：
+```jsx
+/** @jsxImportSource @antv/f2 */
+import { withLegend } from "@antv/f2-vue"
+
+// 自定义 Legend
+const Legend = withLegend((props) => {
+  const { items = [], itemWidth } = props
+
+  return (
+    <group
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {
+        items.map((item) => {
+          const { color, name } = item
+          return (
+            <group
+              className="legend-item"
+              style={{
+                width: itemWidth,
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              data-item={item}
+            >
+              <text
+                attrs={{
+                  fill: color,
+                  text: name,
+                }}
+              />
+            </group>
+          )
+        })
+      }
+    </group>
+  )
+})
+
+export default Legend
+```
+
+### 4. 忽略运行时警告信息 
+在JSX/TSX中使用[图形标签（Shape）](shape.zh.md)时，控制台中会有运行时警告：`[Vue warn]: Failed to resolve component: group` 及 `[Vue warn]: resolveComponent can only be used in render() or setup().`，如需忽略此警告，可在compilerOptions的isCustomElement中添加group标签的判断。
+
+Vue Cli 的 vue.config.js 配置：
+```javascript
+const { defineConfig } = require('@vue/cli-service');
+
+module.exports = defineConfig({
+  chainWebpack: (config) => {
+    config.module
+      .rule('vue')
+      .use('vue-loader')
+      .tap((options) => {
+        options.compilerOptions = {
+          // Clear [Vue warn]: Failed to resolve component: group
+          isCustomElement: (tagName) => ['group'].includes(tagName),
+        };
+        return options;
+      })
+      .end();
+  },
+});
+```
+
+Vite 中的 vite.config.ts 配置：
+```typescript
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    vue(),
+    vueJsx({
+      // Clear [Vue warn]: Failed to resolve component: group
+      isCustomElement: (tagName) => ['group'].includes(tagName),
+    }),
+  ],
+});
 ```
 
 **完整示例可参考**

--- a/packages/vue/examples/vite/package.json
+++ b/packages/vue/examples/vite/package.json
@@ -13,8 +13,6 @@
     "vue": "^3.2.25"
   },
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "^7.17.3",
-    "@rollup/plugin-babel": "^5.3.1",
     "@vitejs/plugin-vue": "^2.3.2",
     "@vitejs/plugin-vue-jsx": "^1.3.10",
     "vite": "^2.9.7"

--- a/packages/vue/examples/vite/src/App.vue
+++ b/packages/vue/examples/vite/src/App.vue
@@ -3,6 +3,7 @@ import { toRaw } from 'vue';
 import Canvas from '@antv/f2-vue';
 import { Chart, Interval, Axis } from '@antv/f2';
 import Grahpic from './graphic';
+import Legend from './legend';
 
 const data1 = [
   { genre: 'Sports', sold: 275 },
@@ -41,6 +42,7 @@ export default {
         <Canvas pixelRatio={ window.devicePixelRatio }>
           <Chart data={ toRaw(chartData) }>
             <Grahpic year={ year } />
+            <Legend />
             <Axis field="genre"/>
             <Axis field="sold"/>
             <Interval x="genre" y="sold" color="genre" />

--- a/packages/vue/examples/vite/src/legend.jsx
+++ b/packages/vue/examples/vite/src/legend.jsx
@@ -1,0 +1,45 @@
+/** @jsxImportSource @antv/f2 */
+import { withLegend } from "@antv/f2-vue"
+
+// 自定义 Legend
+const Legend = withLegend((props) => {
+  const { items = [], itemWidth } = props
+
+  return (
+    <group
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {
+        items.map((item) => {
+          const { color, name } = item
+          return (
+            <group
+              className="legend-item"
+              style={{
+                width: itemWidth,
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              data-item={item}
+            >
+              <text
+                attrs={{
+                  fill: color,
+                  text: name,
+                }}
+              />
+            </group>
+          )
+        })
+      }
+    </group>
+  )
+})
+
+export default Legend

--- a/packages/vue/examples/vite/vite.config.js
+++ b/packages/vue/examples/vite/vite.config.js
@@ -1,23 +1,15 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vueJsx from '@vitejs/plugin-vue-jsx';
-import { babel } from '@rollup/plugin-babel';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    babel({
-      plugins: [
-        [
-          '@babel/plugin-transform-react-jsx',
-          {
-            runtime: 'automatic',
-            importSource: '@antv/f2',
-          },
-        ],
-      ],
-    }),
     vue(),
-    vueJsx(),
+    vueJsx({
+      // Clear [Vue warn]: Failed to resolve component: group.
+      isCustomElement: (tagName) =>
+        ['group'].includes(tagName),
+    }),
   ],
 });

--- a/packages/vue/examples/vue3/package.json
+++ b/packages/vue/examples/vue3/package.json
@@ -13,10 +13,8 @@
     "vue": "^3.2.25"
   },
   "devDependencies": {
-    "@babel/plugin-transform-react-jsx": "~7.17.3",
     "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
-    "@vue/compiler-sfc": "^3.0.0-0"
+    "@vue/cli-service": "~4.5.0"
   },
   "browserslist": [
     "> 1%",

--- a/packages/vue/examples/vue3/src/App.vue
+++ b/packages/vue/examples/vue3/src/App.vue
@@ -3,6 +3,7 @@ import { toRaw } from 'vue';
 import Canvas from '@antv/f2-vue';
 import { Chart, Interval, Axis } from '@antv/f2';
 import Grahpic from './graphic';
+import Legend from './legend';
 
 const data1 = [
   { genre: 'Sports', sold: 275 },
@@ -41,6 +42,7 @@ export default {
         <Canvas pixelRatio={ window.devicePixelRatio }>
           <Chart data={ toRaw(chartData) }>
             <Grahpic year={ year } />
+            <Legend />
             <Axis field="genre"/>
             <Axis field="sold"/>
             <Interval x="genre" y="sold" color="genre" />

--- a/packages/vue/examples/vue3/src/legend.jsx
+++ b/packages/vue/examples/vue3/src/legend.jsx
@@ -1,0 +1,45 @@
+/** @jsxImportSource @antv/f2 */
+import { withLegend } from "@antv/f2-vue"
+
+// 自定义 Legend
+const Legend = withLegend((props) => {
+  const { items = [], itemWidth } = props
+
+  return (
+    <group
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {
+        items.map((item) => {
+          const { color, name } = item
+          return (
+            <group
+              className="legend-item"
+              style={{
+                width: itemWidth,
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              data-item={item}
+            >
+              <text
+                attrs={{
+                  fill: color,
+                  text: name,
+                }}
+              />
+            </group>
+          )
+        })
+      }
+    </group>
+  )
+})
+
+export default Legend

--- a/packages/vue/examples/vue3/vue.config.js
+++ b/packages/vue/examples/vue3/vue.config.js
@@ -1,20 +1,14 @@
 module.exports = {
   chainWebpack: (config) => {
     config.module
-      .rule('F2')
-      .test(/\.jsx$/)
-      .use('babel')
-      .loader('babel-loader')
-      .options({
-        plugins: [
-          [
-            '@babel/plugin-transform-react-jsx',
-            {
-              runtime: 'automatic',
-              importSource: '@antv/f2',
-            },
-          ],
-        ],
+      .rule('vue')
+      .use('vue-loader')
+      .tap((options) => {
+        options.compilerOptions = {
+          // Clear [Vue warn]: Failed to resolve component: group.
+          isCustomElement: (tagName) => ['group'].includes(tagName),
+        };
+        return options;
       })
       .end();
   },

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -1,0 +1,16 @@
+import * as F2 from '@antv/f2';
+import { toRawView } from './util';
+
+export const withLine = (View: Function) => F2.withLine(toRawView(View));
+export const withArea = (View: Function) => F2.withArea(toRawView(View));
+export const withInterval = (View: Function) => F2.withInterval(toRawView(View));
+export const withPoint = (View: Function) => F2.withPoint(toRawView(View));
+export const withAxis = (View: Function) => F2.withAxis(toRawView(View));
+export const withLegend = (View: Function) => F2.withLegend(toRawView(View));
+export const withGuide = (View: Function) => F2.withGuide(toRawView(View));
+export const withTooltip = (View: Function) => F2.withTooltip(toRawView(View));
+export const withTreemap = (View: Function) => F2.withTreemap(toRawView(View));
+export const withSunburst = (View: Function) => F2.withSunburst(toRawView(View));
+export const withPieLabel = (View: Function) => F2.withPieLabel(toRawView(View));
+export const withGauge = (View: Function) => F2.withGauge(toRawView(View));
+export const withScrollBar = (View: Function) => F2.withScrollBar(toRawView(View));

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,34 +1,6 @@
-import { h, toRaw, isVNode } from 'vue';
-import { Canvas, Children } from '@antv/f2';
-
-const toRawChildren = (slots) => {
-  return Children.map(slots, (slot) => {
-    if (!slot) return slot;
-    const element = toRaw(slot);
-
-    // vnode
-    if (isVNode(element)) {
-      const { key, ref, type, props, children } = element;
-      if (children) {
-        props.children = toRawChildren(children);
-      }
-      return {
-        key,
-        ref,
-        type,
-        props,
-      };
-    }
-
-    // slot
-    if (element.default) {
-      const children = element.default();
-      return toRawChildren(children);
-    }
-
-    return null;
-  });
-};
+import { h, toRaw } from 'vue';
+import { Canvas } from '@antv/f2';
+import { toRawChildren } from './util';
 
 export default {
   props: {
@@ -105,3 +77,5 @@ export default {
     canvas.destroy();
   },
 };
+
+export * from './components';

--- a/packages/vue/src/util.ts
+++ b/packages/vue/src/util.ts
@@ -1,0 +1,51 @@
+import { toRaw, isVNode, Slots, VNode, VNodeNormalizedChildren } from 'vue';
+import { Children } from '@antv/f2';
+import { ComponentContext, Updater } from '@antv/f2/es/base/component';
+
+// 自定义图形及自定义组件执行渲染函数获得VNode，然后再转换为Props。
+// https://github.com/antvis/F2/blob/master/packages/f2/src/base/diff.ts#L117
+// return type(this.props, context, updater);
+export const toRawView = (View: Function) => {
+  return (props: Record<string, unknown>, context: ComponentContext, updater: Updater) =>
+    toRawChildren(Reflect.apply(View, undefined, [props, context, updater]));
+};
+
+export const toRawChildren = (slots: VNode | VNodeNormalizedChildren) => {
+  return Children.map(slots, (slot: VNode | Slots) => {
+    if (!slot) return slot;
+    const element = toRaw(slot);
+
+    // vnode
+    if (isVNode(element)) {
+      const { key, ref, type, props, children } = element;
+      if (typeof type === 'function') {
+        const isF2Component = type.prototype && type.prototype.isF2Component;
+        if (!isF2Component) {
+          return {
+            type: toRawView(type),
+            key,
+            ref,
+            props,
+          };
+        }
+      }
+      return {
+        key,
+        ref,
+        type,
+        props: {
+          ...props,
+          children: toRawChildren(children),
+        },
+      };
+    }
+
+    // slot
+    if (element.default) {
+      const children = element.default();
+      return toRawChildren(children.length === 1 ? children[0] : children);
+    }
+
+    return null;
+  });
+};


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/F2/blob/master/CONTRIBUTING.zh-CN.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/f2/blob/master/CONTRIBUTING.zh-CN.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
解决Vue3项目中编译包含自定义View及自定义Shape时需要使用@babel/plugin-transform-react-jsx的问题。详见examples中的vue3-ts项目示例。
备注：[自定义图表组件](https://antv-f2.gitee.io/zh/docs/tutorial/advanced/custom-view)需引用@antv/f2-vue中的HOC。例如: `import { withLegend } from "@antv/f2-vue"`。
